### PR TITLE
Add parameter to download FHIR resources by subject= again

### DIFF
--- a/R-cds2db/cds2db/R/04_Load_Resources.R
+++ b/R-cds2db/cds2db/R/04_Load_Resources.R
@@ -285,8 +285,15 @@ loadResourcesByPatientIDFromFHIRServer <- function(patient_ids_per_ward, table_d
                     suffix = "\n",
                     na_replacement = "Not present in DB")
 
+  # the parameter FHIR_SEARCH_PIDS_BY_SUBJECT decides if the patient IDs are
+  # passed by subject or patient in the FHIR search request
+  id_param_str <- ifelse (etlutils::isDefinedAndTrue("FHIR_SEARCH_PIDS_BY_SUBJECT"), "subject", "patient")
+
   # Load all data of relevant patients from FHIR server
-  resource_tables_fhir <- etlutils::fhirLoadMultipleResourcesByPID(pids_with_last_updated, table_descriptions, resources_add_search_parameter)
+  resource_tables_fhir <- etlutils::fhirLoadMultipleResourcesByPID(pids_with_last_updated,
+                                                                   table_descriptions,
+                                                                   id_param_str,
+                                                                   resources_add_search_parameter)
 
   raw_fhir_resources <- resource_tables_fhir$raw_fhir_resources
   # The pids_with_last_updated now only contains persons who were older than MIN_PATIENT_AGE at

--- a/R-cds2db/cds2db_config.toml
+++ b/R-cds2db/cds2db_config.toml
@@ -53,6 +53,11 @@ FHIR_TOKEN_REFRESH_PASSWORD = ""
 
 FHIR_SEARCH_CURL_TIMEOUT = 1800 # timeout for curl requests on a FHIR server in seconds
 
+# Per default FHIR search request for resources with a specific subject (e.g. patient) are
+# performed with patient="patient_id". If there are any reasons this behaviour can be changed
+# to "subject=patient_id" by setting the following parameter to TRUE.
+# FHIR_SEARCH_PIDS_BY_SUBJECT = TRUE
+
 MAX_CHARACTER_LENGTH_FOR_GET_REQUESTS         = 2083 # max character length for GET-Requests [ehemals MAX_LEN]
 MAX_CHARACTER_LENGTH_FOR_GET_REQUESTS_RESERVE = 300  # reserve 300 characters for further parameters, whose length cannot estimated [ehemals RES_LEN]
 


### PR DESCRIPTION
refs #696
The default (if this new parameter is not defined or false) loads all PID dependent FHIR resources by patient=