### PR TITLE
fix: added debian package libudunits2-dev as dependency for R package…

### DIFF
--- a/Dockerfile_R
+++ b/Dockerfile_R
@@ -19,7 +19,7 @@ RUN apt-get update && apt-get install -y -q \
 # etlutils
 
 RUN apt-get install -y \
-	libssl-dev libcurl4-openssl-dev libpq-dev libxml2-dev
+	libssl-dev libcurl4-openssl-dev libpq-dev libxml2-dev libudunits2-dev
 
 RUN /rocker_scripts/bin/install2.r -n $NCPUS memuse
 RUN /rocker_scripts/bin/install2.r -n $NCPUS openxlsx


### PR DESCRIPTION
Dockerfile_R does not build because the newly added R package units has a missing dependency in the container