### PR TITLE
Add scoped R formatting wrappers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,14 +25,32 @@ Before each commit that touches R code, format the affected R code with the
 repository formatter:
 
 ```sh
-Rscript tools/style.R
+Rscript tools/style-changed.R
 ```
+
+Use `Rscript tools/style-full.R` when you intentionally want to re-run the
+formatter across the complete configured R scope.
+`tools/style-changed.R` includes R files changed against `origin/develop` and
+R files currently changed in the working tree or index.
+
+`tools/style-full.R` can be started from the repository root or from a
+subdirectory. It temporarily switches to the repository root and restores the
+previous working directory afterwards.
+
+For faster RStudio workflows, use `tools/style-current-file.R` for the active
+saved editor file or `tools/style-current-package.R` for the active package
+project. Both wrappers use the same formatter functions as the full repository
+run and restore the previous working directory afterwards.
 
 The formatter uses:
 
 - `.editorconfig` for editor and whitespace rules
 - `tools/styler-style.R` for the `styler` style definition
-- `tools/style.R` as the executable repository formatting command
+- `tools/style.R` for the shared formatter implementation
+- `tools/style-changed.R` for formatting changed R files only
+- `tools/style-full.R` for formatting the complete configured R scope
+- `tools/style-current-file.R` and `tools/style-current-package.R` for smaller
+  RStudio-triggered formatting runs
 
 The formatting covers the repository's R project areas, including the R code
 under `Postgres-cds_hub/R-initcdstoolchain`.
@@ -52,7 +70,7 @@ use the style definition configured in this repository. A dedicated keyboard
 shortcut for the styler addin, for example for the active file, is recommended.
 
 Saving normally in RStudio does not replace the formatting run. Before committing,
-`Rscript tools/style.R` remains the required check.
+`Rscript tools/style-changed.R` remains the expected local formatting run.
 
 ### Checking Style Locally
 

--- a/Postgres-cds_hub/R-initcdstoolchain/initcdstoolchain/R/Init_01_Expand_TableDescription.R
+++ b/Postgres-cds_hub/R-initcdstoolchain/initcdstoolchain/R/Init_01_Expand_TableDescription.R
@@ -134,7 +134,6 @@ addEmptyRowsBeforeNewResource <- function(table) {
 #' \code{\link[etlutils]{isSimpleNotEmptyString}}, \code{\link[etlutils]{getAfterLastSlash}},
 #' \code{\link[etlutils]{getBeforeLastSlash}}, \code{\link[etlutils]{replacePatternsInString}}
 expandTableDescriptionInternal <- function(table_description_collapsed, expansion_tables) {
-
   table <- data.table::copy(table_description_collapsed)
 
   replace_patterns <- extractReplacePatterns(table)
@@ -169,7 +168,6 @@ expandTableDescriptionInternal <- function(table_description_collapsed, expansio
   row <- 1
   last_row_index <- nrow(table)
   while (row <= last_row_index) {
-
     if (!is.na(table$RESOURCE[row])) {
       resource <- table$RESOURCE[row]
       if (!is.na(table$RESOURCE_PREFIX[row])) {
@@ -239,7 +237,6 @@ expandTableDescriptionInternal <- function(table_description_collapsed, expansio
       reference_prefix <- getResourceAbbreviation(table_description_collapsed, reference_type)
       new_table[row, REFERENCE_ID_COLUMN_NAME := paste0(reference_prefix, "_id")]
     }
-
   }
 
   # set the column 'COLUMN_NAME' directly in front of column 'FHIR_EXPRESSION'
@@ -250,7 +247,6 @@ expandTableDescriptionInternal <- function(table_description_collapsed, expansio
   table[, COLUMN_NAME := tolower(COLUMN_NAME)]
   # add empty row after every last entry of a resource (and before a new resource starts)
   table <- addEmptyRowsBeforeNewResource(table)
-
 }
 
 #' Expand Table Description from an Excel File

--- a/Postgres-cds_hub/R-initcdstoolchain/initcdstoolchain/R/Init_02_Create_Database_Scripts.R
+++ b/Postgres-cds_hub/R-initcdstoolchain/initcdstoolchain/R/Init_02_Create_Database_Scripts.R
@@ -113,7 +113,6 @@ extractBetweenQuotes <- function(string) {
 #'
 #' @export
 removePlaceholderLines <- function(input_string, placeholder) {
-
   placeholder_escaped <- etlutils::getEscaped(placeholder)
 
   # Check if input_string ends with a newline
@@ -282,7 +281,6 @@ replace <- function(original, replacement, string) {
 #####################################
 
 createHeader <- function(script_rights_definition) {
-
   add <- function(...) {
     header <<- paste0(header, paste0(...), "\n")
   }
@@ -391,7 +389,6 @@ convertTemplate <- function(tables_descriptions,
                             loop_row = 1,
                             indentation = "",
                             recursion = 0) {
-
   rights_first_row <- script_rights_definition[1]
   # Load SQL template
   content <- ifelse (is.na(template_content), getTemplateContent(template_name), template_content)
@@ -582,7 +579,6 @@ convertTemplate <- function(tables_descriptions,
   }
 
   if (recursion == 0) {
-
     placeholders <- extractPlaceholders(content)
     if (length(placeholders)) {
       warning("There are unreplaced placeholders in the file ", file_name, ":\n", placeholders)
@@ -593,7 +589,6 @@ convertTemplate <- function(tables_descriptions,
     } else {
       cat(" skipped\n")
     }
-
   }
   # Write the modified content to the file
   return(content)
@@ -604,7 +599,6 @@ convertTemplate <- function(tables_descriptions,
 ########
 
 loadDatabaseRightsAndConvertDefinition <- function() {
-
   rights_definition_file_name <- getRightsDefinitionFileName()
   rights_and_convert_definition <- etlutils::readExcelFileAsTableList(rights_definition_file_name)
 
@@ -689,5 +683,4 @@ createDatabaseScriptsFromTemplates <- function() {
       }
     }
   }
-
 }

--- a/R-cds2db/cds2db/R/00_Init_Validation.R
+++ b/R-cds2db/cds2db/R/00_Init_Validation.R
@@ -167,7 +167,6 @@ validateConfig <- function() {
     if (has_data_import_fhir_pids && (has_data_import_range_start || has_data_import_range_end || has_data_import_resource_types)) {
       stop("DATA_IMPORT_FHIR_PIDS must be defined alone and must not be combined with DATA_IMPORT_RANGE_START, DATA_IMPORT_RANGE_END or DATA_IMPORT_RESOURCE_TYPES.")
     }
-
   }
 
   ###
@@ -178,5 +177,4 @@ validateConfig <- function() {
       stop("FHIR_SEARCH_ENCOUNTER_ADDITIONAL_PARAMETERS can not contain '&date=' if degub encouter start dates are defined.")
     }
   }
-
 }

--- a/R-cds2db/cds2db/R/00_Main.R
+++ b/R-cds2db/cds2db/R/00_Main.R
@@ -99,7 +99,6 @@ retrieve <- function(phase_a_starts = NULL, ignore_newer_db_version = FALSE, val
 
   retrieve_runlevel_message <- if (isProcess("DataImport")) "Run Data Import Retrieve" else "Run Retrieve"
   try(etlutils::runLevel1(retrieve_runlevel_message, {
-
     if (!skip_db_operations) {
       # Reset database lock from unfinished previous cds2db run
       etlutils::runLevel2("Reset database lock from unfinished previous run", {
@@ -109,7 +108,6 @@ retrieve <- function(phase_a_starts = NULL, ignore_newer_db_version = FALSE, val
       })
       # Check if we must create references for old data (should be executed exactly once and then never again)
       etlutils::runLevel2("Create references for old data", {
-
         debug_active <- etlutils::isDefinedAndTrue("DEBUG_RECALCULATE_INVALID_REFS") || etlutils::isDefinedAndNotEmpty("DEBUG_RECALCULATE_REFS_FOR_RESOURCES")
 
         if (mustCreateReferencesForOldData() || debug_active) {
@@ -219,7 +217,6 @@ retrieve <- function(phase_a_starts = NULL, ignore_newer_db_version = FALSE, val
       })
 
       if (!all_empty_raw) {
-
         etlutils::runLevel2("Convert RAW tables to typed tables", {
           fhir_table_descriptions <- extractTableDescriptionsList(fhir_table_descriptions)
           resource_tables <- convertTypes(resource_tables_raw_diff, fhir_table_descriptions)
@@ -236,10 +233,8 @@ retrieve <- function(phase_a_starts = NULL, ignore_newer_db_version = FALSE, val
             stop_if_table_not_empty = TRUE
           )
         })
-
       }
     }
-
   }))
 
   # Reset lock and close all database connections. Do not surround this with runLevelX!
@@ -247,10 +242,12 @@ retrieve <- function(phase_a_starts = NULL, ignore_newer_db_version = FALSE, val
 
   # Generate finish message
   finish_message <- etlutils::generateFinishMessage()
-  if (!etlutils::isErrorOccured() &&
-    (etlutils::isDefinedAndTrue("all_wards_empty") ||
-      etlutils::isDefinedAndTrue("all_empty_fhir") ||
-      etlutils::isDefinedAndTrue("all_empty_raw"))) {
+  if (
+    !etlutils::isErrorOccured() &&
+      (etlutils::isDefinedAndTrue("all_wards_empty") ||
+        etlutils::isDefinedAndTrue("all_empty_fhir") ||
+        etlutils::isDefinedAndTrue("all_empty_raw"))
+  ) {
     finish_message <- paste0(
       "\nModule '", etlutils::getModuleName(), "' finished with no errors but the result was empty (see warnings above).\n"
     )
@@ -260,5 +257,4 @@ retrieve <- function(phase_a_starts = NULL, ignore_newer_db_version = FALSE, val
   finish_message <- etlutils::appendDebugWarning(finish_message)
 
   return(etlutils::finalize(finish_message))
-
 }

--- a/R-cds2db/cds2db/R/02_Get_PIDs.R
+++ b/R-cds2db/cds2db/R/02_Get_PIDs.R
@@ -159,7 +159,6 @@ loadInitialPatientsAndEncountersFromFiles <- function(path_to_files) {
 #' @return A named list where each element is a data.table with `pid` and `encounter_id` for a specific ward.
 #'
 extractPIDsSplittedByWard <- function(encounters, all_wards_filter_patterns) {
-
   pids_splitted_by_ward <- list()
 
   for (i in seq_along(all_wards_filter_patterns)) {
@@ -214,7 +213,6 @@ extractPIDsSplittedByWard <- function(encounters, all_wards_filter_patterns) {
 #' saved as RData files.
 #'
 getEncounters <- function(table_description, current_datetime) {
-
   runLevel3("Get Enconters", {
     # Refresh token, if defined
     etlutils::fhirsearchRefreshToken()
@@ -334,7 +332,6 @@ getEncounters <- function(table_description, current_datetime) {
           etlutils::formatStringStyle(request_encounter[[1]], fg = 2, underline = TRUE)
         )
       }
-
     })
 
     runLevel3Line("Validate encounter subject reference", {
@@ -380,7 +377,6 @@ getEncounters <- function(table_description, current_datetime) {
 #' @return the relevant patient IDs per ward
 #'
 getPIDsSplittedByWard <- function(create_single_pids_per_ward, wards_min_encounter_start_date = NULL, log_result = TRUE) {
-
   read_pids_from_file <- exists("DEBUG_PATH_TO_RAW_RDATA_FILES")
 
   if (read_pids_from_file) {

--- a/R-cds2db/cds2db/R/03_Get_Table_Descriptions.R
+++ b/R-cds2db/cds2db/R/03_Get_Table_Descriptions.R
@@ -57,7 +57,6 @@ getTableDescriptionsTable <- function(columns = NA) {
 #'
 #' @keywords data manipulation
 getFhircrackrTableDescriptions <- function(table_description_table = NA) {
-
   isPIDDependant <- function(table_description) {
     resource_name <- table_description@resource@.Data
     return(resource_name == "Patient" || "subject/reference" %in% table_description@cols@.Data || "patient/reference" %in% table_description@cols@.Data)

--- a/R-cds2db/cds2db/R/04_Load_Resources.R
+++ b/R-cds2db/cds2db/R/04_Load_Resources.R
@@ -220,7 +220,6 @@ addDataImportFHIRDateSearchParameters <- function(table_descriptions,
 #'   and the last element is a table representing the ward and patient ID per date.
 #'
 loadResourcesByPatientIDFromFHIRServer <- function(pids_splitted_by_ward, table_descriptions) {
-
   patient_ids <- unique(unlist(data.table::rbindlist(pids_splitted_by_ward, use.names = TRUE, fill = TRUE)[, .(patient_id)]))
 
   if (!isProcess("DataImport")) {
@@ -272,11 +271,9 @@ loadResourcesByPatientIDFromFHIRServer <- function(pids_splitted_by_ward, table_
 
     # Create the query for the last insert/update date for every ID
     query <- paste0(
-      "SELECT pat_id, MAX(
-        last_check_datetime) AS last_insert_datetime\n",
+      "SELECT pat_id, MAX(last_check_datetime) AS last_insert_datetime\n",
       "FROM v_patient\n",
-      "WHERE pat_id = ANY(
-        $1::text[])\n",
+      "WHERE pat_id = ANY($1::text[])\n",
       "GROUP BY pat_id;"
     )
 
@@ -321,7 +318,7 @@ loadResourcesByPatientIDFromFHIRServer <- function(pids_splitted_by_ward, table_
 
   # the parameter FHIR_SEARCH_PIDS_BY_SUBJECT decides if the patient IDs are
   # passed by subject or patient in the FHIR search request
-  id_param_str <- ifelse (etlutils::isDefinedAndTrue("FHIR_SEARCH_PIDS_BY_SUBJECT"), "subject", "patient")
+  id_param_str <- ifelse(etlutils::isDefinedAndTrue("FHIR_SEARCH_PIDS_BY_SUBJECT"), "subject", "patient")
 
   # Load all data of relevant patients from FHIR server
   resource_tables_fhir <- etlutils::fhirsearchMultipleResourcesByPID(
@@ -337,10 +334,12 @@ loadResourcesByPatientIDFromFHIRServer <- function(pids_splitted_by_ward, table_
   pids_with_last_updated <- resource_tables_fhir$pids_with_last_updated
 
   # THIS EXCEPTION MUST BE GENERALIZED OR REMOVED HERE! FHIR resource names should not be used here.
-  if (etlutils::isSubProcess("DataImport.ResourceTypes") &&
+  if (
+    etlutils::isSubProcess("DataImport.ResourceTypes") &&
     hasDataImportDateRange() &&
     "DiagnosticReport" %in% names(table_descriptions) &&
-    (!("DiagnosticReport" %in% names(raw_fhir_resources)) || !nrow(raw_fhir_resources[["DiagnosticReport"]]))) {
+    (!("DiagnosticReport" %in% names(raw_fhir_resources)) || !nrow(raw_fhir_resources[["DiagnosticReport"]]))
+  ) {
     catInfoMessage("Info: No DiagnosticReport resources found with date search parameter. Retrying with issued.\n")
     diagnostic_report_add_search_parameter <- addDataImportFHIRDateSearchParameters(
       table_descriptions["DiagnosticReport"],

--- a/R-cds2db/cds2db/R/06_Create_References.R
+++ b/R-cds2db/cds2db/R/06_Create_References.R
@@ -110,7 +110,6 @@ createReferences <- function(resource_tables, common_encounter_fhir_identifier_s
 
   # if the resources are null that indicates that we must create all references for old data
   if (is.null(resource_tables)) {
-
     writeTableWithReferencesToDB <- function(resource_name, resource_table, calculated_col_names, lock_id) {
       id_col_name <- etlutils::fhirdbGetIDColumn(resource_name)
 

--- a/R-cds2db/cds2db/R/06_Create_References_Functions.R
+++ b/R-cds2db/cds2db/R/06_Create_References_Functions.R
@@ -35,7 +35,6 @@ createReferencesForEncounters <- function(encounters, common_encounter_fhir_iden
   # Find the best fitting parent encounter by timestamp and prefer inpatient encounters
   #
   findParentEncounter <- function(child_row, candidate_parent_encounters) {
-
     child_start <- child_row$enc_period_start
     child_end <- child_row$enc_period_end
     # filter candidates that enclose the child encounter
@@ -46,7 +45,6 @@ createReferencesForEncounters <- function(encounters, common_encounter_fhir_iden
         (is.na(child_end) | is.na(enc_period_end) | enc_period_end >= child_end)
     ]
     if (nrow(candidate_parent_encounters) > 1) {
-
       getParentCandidates <- function(candidate_parent_encounters, enc_class) {
         new_candidate_parent_encounters <- candidate_parent_encounters[enc_class_code == enc_class]
         if (nrow(new_candidate_parent_encounters) >= 1) {
@@ -112,7 +110,6 @@ createReferencesForEncounters <- function(encounters, common_encounter_fhir_iden
   }
 
   etlutils::runLevel2("Fill the enc_partof_calculated_ref column level by level (direct copy)", {
-
     etlutils::runLevel2("... from existing part_of references", {
       for (i in 2:3) { # for each level except the first (einrichtungskontakt)
         encounters_of_lvl <- encounters_by_type[[i]]
@@ -174,7 +171,6 @@ createReferencesForEncounters <- function(encounters, common_encounter_fhir_iden
               patient_ref <- encounters_of_lvl$enc_patient_ref[enc_index]
               candidate_parent_encounters <- parent_encounters_of_lvl[enc_patient_ref == patient_ref]
               if (nrow(candidate_parent_encounters)) {
-
                 parent_encounter <- findParentEncounter(
                   child_row = encounters_of_lvl[enc_index],
                   candidate_parent_encounters = candidate_parent_encounters
@@ -303,7 +299,6 @@ createReferencesForEncounters <- function(encounters, common_encounter_fhir_iden
 
 createReferencesForResource <- function(encounters, resource_name, resource_table, start_column_names) {
   etlutils::runLevel2Line(paste0("Create Encounter References for ", resource_name), {
-
     calculated_ref_col_name <- getEncounterCalculatedReferenceColumnName(resource_name)
     # Once the data has been retrieved from the database, we only need to calculate the cal_ref
     # columns for the resources that have no valid value, so all others can be removed.

--- a/R-cds2db/cds2db/R/09_Debug_Functions.R
+++ b/R-cds2db/cds2db/R/09_Debug_Functions.R
@@ -37,7 +37,6 @@ debugAddPatientIdentifier <- function(resource_tables) {
   resource_tables$Patient[, pat_identifier_value := sapply(pat_identifier_value, function(x) addValue(x, old_value_suffix = old_value_suffix, new_value_suffix = new_value_suffix))]
 
   return(resource_tables)
-
 }
 
 debugAddPatient <- function(Patient, patient_IDs_per_ward) {

--- a/R-cds2db/test/test_01_check_Data_Import.R
+++ b/R-cds2db/test/test_01_check_Data_Import.R
@@ -35,9 +35,11 @@ if (exists("resource_tables")) {
     normalized_targets
   }
 
-  if (etlutils::isProcess("DataImport") ||
+  if (
+    etlutils::isProcess("DataImport") ||
     etlutils::isSubProcess("DataImport.All") ||
-    etlutils::isSubProcess("DataImport.ResourceTypes")) {
+    etlutils::isSubProcess("DataImport.ResourceTypes")
+  ) {
     etlutils::catInfoMessage(
       "Info: Skip RAW column blanking during DataImport so the backfill can be reloaded.\n"
     )

--- a/R-cds2db/test/test_02_change_RAW_Data.R
+++ b/R-cds2db/test/test_02_change_RAW_Data.R
@@ -230,7 +230,6 @@ if (exists("TOOLCHAIN_DAY")) {
     pid <- addDrugs("UKB-0001_23", "M04AA51")
     addConditions(pid, "N18.5")
     addObservation(pid, "62238-1", value = 19, unit = "ml/min")
-
   })
 
   # Update the resource_tables list with the modified data tables

--- a/R-cds2db/test/test_02a_change_RAW_Data.R
+++ b/R-cds2db/test/test_02a_change_RAW_Data.R
@@ -266,7 +266,6 @@ if (exists("TOOLCHAIN_DAY")) {
     addObservation(pid, "2951-2", value = 7, unit = "mg/dL", referencerange_low_value = 5, referencerange_high_value = 10) # kein MRP
     addObservation(pid, "2951-2", value = 3, unit = "mg/dL", referencerange_low_value = 5, referencerange_high_value = 10)
     addObservation(pid, "2951-2", value = 7, unit = "mg/dL", referencerange_low_value = 5, referencerange_high_value = 10) # kein MRP
-
   })
 
   # Update the resource_tables list with the modified data tables

--- a/R-cds2db/test/test_04_change_RAW_Data.R
+++ b/R-cds2db/test/test_04_change_RAW_Data.R
@@ -210,7 +210,6 @@ if (exists("TOOLCHAIN_DAY")) {
     # 15:  0 |  0 |  1 | invalid Obs - non convertible unit
     pid <- addDrugs("UKB-0001_15", "C03DA02")
     addObs(pid, list(ref_range_inv))
-
   })
 
   # Update the resource_tables list with the modified data tables

--- a/R-cds2db/test/test_05_change_REDCap_Data.R
+++ b/R-cds2db/test/test_05_change_REDCap_Data.R
@@ -10,5 +10,4 @@ if (isDebugDay()) {
     patient_ids = pat_ids,
     day_offset = 0.5
   )
-
 }

--- a/R-cds2db/test/test_08_change_RAW_Data.R
+++ b/R-cds2db/test/test_08_change_RAW_Data.R
@@ -240,7 +240,6 @@ if (exists("TOOLCHAIN_DAY")) {
     # Add Drug in MedicationRequests without Medication
     pid <- addDrugsWithoutMedications("UKB-0001_24", c("J02AC01", "A04AA01"))
     addDrugs(pid, c("J04AB02", "J05AP52"))
-
   })
 
   # Update the resource_tables list with the modified data tables

--- a/R-cds2db/test/test_09_change_RAW_Data.R
+++ b/R-cds2db/test/test_09_change_RAW_Data.R
@@ -166,7 +166,6 @@ if (exists("TOOLCHAIN_DAY")) {
     # pid <- "UKB-0001_10"
     # addDrugs(pid, "N06AX22", day_offset = -0.3, period_type = "timing_events")
     # addDrugs(pid, "J01MA02", period_type = "all_timestamps_NA")
-
   })
 
   # Update the resource_tables list with the modified data tables

--- a/R-cds2db/test/test_11_change_RAW_Data.R
+++ b/R-cds2db/test/test_11_change_RAW_Data.R
@@ -182,7 +182,6 @@ if (exists("TOOLCHAIN_DAY")) {
     # ATC und mehrere Diagnosen mit mehreren Zeilen in der nach ICD gesplitteten Drug Disease Liste
     pid <- addDrugs("UKB-0001_12", "L01XX05")
     addConditions(pid, c("D69.58", "D69.61"))
-
   })
 
   # Update the resource_tables list with the modified data tables

--- a/R-cds2db/test/test_14_change_RAW_Data.R
+++ b/R-cds2db/test/test_14_change_RAW_Data.R
@@ -48,7 +48,6 @@ DEBUG_PATH_TO_RAW_RDATA_FILES <- "./R-cds2db/test/tables/"
 
 
 if (exists("TOOLCHAIN_DAY")) {
-
   source("./R-cds2db/test/test_common_data_preparation.R", local = TRUE)
   testSetResourceTables(resource_tables)
 

--- a/R-cds2db/test/test_XX_change_RAW_Data_template.R
+++ b/R-cds2db/test/test_XX_change_RAW_Data_template.R
@@ -23,5 +23,4 @@ if (exists("TOOLCHAIN_DAY")) {
   } else if (TOOLCHAIN_DAY == 3) {
     # ...
   }
-
 }

--- a/R-cds2db/test/test_common_data_preparation.R
+++ b/R-cds2db/test/test_common_data_preparation.R
@@ -689,7 +689,6 @@ testDischarge <- function(pid) {
 }
 
 duplicatePatients <- function(count, duplicated_start_index = 1) {
-
   addPatientIdIndex <- function(old_id, index, resource_table, resource_name) {
     new_id <- paste0(old_id, "_", index)
     id_column <- etlutils::fhirdbGetIDColumn(resource_name)
@@ -768,7 +767,6 @@ addDrugs <- function(pid, codes = NULL, day_offset = -0.4, authoredon = NA, peri
                        "timing_events",
                        "all_timestamps_NA"
                      ), encounter_id = NULL, timing_events_count = 3, timing_events_day_offset = 2, timing_repeat_end_offset = 5, ref_codes = NULL) {
-
   period_type <- match.arg(period_type)
 
   # Load template tables from environment
@@ -913,7 +911,6 @@ addDrugsWithoutMedications <- function(pid, codes = NULL, day_offset = -0.4, aut
                                          "timing_events",
                                          "all_timestamps_NA"
                                        ), encounter_id = NULL, timing_events_count = 3, timing_events_day_offset = 2, timing_repeat_end_offset = 5) {
-
   period_type <- match.arg(period_type)
 
   # Load template tables from environment
@@ -1041,7 +1038,6 @@ createReferenceRange <- function(referencerange_low_value = NULL, referencerange
                                  referencerange_high_value = NULL, referencerange_high_code = NULL,
                                  referencerange_type_code = NULL,
                                  referencerange_low_system = NULL, referencerange_high_system = NULL) {
-
   if (!etlutils::isSimpleNAorNULL(referencerange_low_value) || !etlutils::isSimpleNAorNULL(referencerange_high_value)) {
     reference_range <- etlutils::namedListByParam(
       referencerange_low_value,
@@ -1155,7 +1151,6 @@ addObservationWithRanges <- function(pid, code, day_offset = -0.5, value = NULL,
       low_systems  <- addValue(low_systems, prefix, range$referencerange_low_system)
       high_systems <- addValue(high_systems, prefix, range$referencerange_high_system)
       type_codes   <- addValue(type_codes, prefix2, range$referencerange_type_code)
-
     }
     pasteRAW <- function(vec) {
       raw <- paste0(vec, collapse = " ~ ")

--- a/R-cdstoolchain/DeleteDBAndREDCap.R
+++ b/R-cdstoolchain/DeleteDBAndREDCap.R
@@ -30,7 +30,6 @@ if (interactive()) {
   # delete REDCap
   config_db2frontend <- db2frontend::initFrontend2DB()
   db2frontend::deleteRedcapContent()
-
 }
 
 end_full <- Sys.time()

--- a/R-cdstoolchain/StartCDSToolChain.R
+++ b/R-cdstoolchain/StartCDSToolChain.R
@@ -108,8 +108,10 @@ setDebugPathToConfigToml <- function(module_name) {
 
 shouldStart <- function(module_name) {
   if (!etlutils::isErrorOccured()) {
-    if (!exists("DEBUG_START_SINGLE_MODULE") ||
-      (exists("DEBUG_START_SINGLE_MODULE") && identical(DEBUG_START_SINGLE_MODULE, module_name))) {
+    if (
+      !exists("DEBUG_START_SINGLE_MODULE") ||
+      (exists("DEBUG_START_SINGLE_MODULE") && identical(DEBUG_START_SINGLE_MODULE, module_name))
+    ) {
       resetMemory()
       setDebugPathToConfigToml(module_name)
       return(TRUE)
@@ -122,7 +124,6 @@ shouldStart <- function(module_name) {
 # match the ward names defined in the PHASES_WARD definitions in config_dataprocessor. If there is a
 # mismatch, it throws an error with details about the mismatch.
 validateConfigs <- function() {
-
   args <- commandArgs(trailingOnly = TRUE)
   if ("--ignoreWardNameMismatch" %in% args) {
     etlutils::catWarningMessage("Ignoring ward name mismatch between config_cds2db and config_dataprocessor due to --ignoreWardNameMismatch argument.")

--- a/R-cdstoolchain/StartDebugDataImport.R
+++ b/R-cdstoolchain/StartDebugDataImport.R
@@ -111,8 +111,7 @@ source(DEBUG_CHANGE_RAW_DATA_SCRIPT_NAME, local = FALSE)
 countFilledRows <- function(resource_type, column_name) {
   cds2db::init(validate_config = FALSE)
   query <- paste0(
-    "SELECT COUNT(
-      *) AS filled_rows\n",
+    "SELECT COUNT(*) AS filled_rows\n",
     "FROM v_", tolower(resource_type), "_last_version\n",
     "WHERE ", column_name, " IS NOT NULL;\n"
   )

--- a/R-dataprocessor/dataprocessor/R/00_Main.R
+++ b/R-dataprocessor/dataprocessor/R/00_Main.R
@@ -98,7 +98,6 @@ runSubmodules <- function() {
 
   # Iterate over each submodule directory
   for (dir in submodule_dirs) {
-
     submodule_name <- basename(dir)
     etlutils::setSubmoduleName(submodule_name)
 
@@ -118,11 +117,9 @@ runSubmodules <- function() {
       if (file.exists(start_script)) {
         source(start_script)
       }
-
     })
 
     etlutils::removeSubmoduleName()
-
   }
 }
 
@@ -134,7 +131,6 @@ startDataprocessorModule <- function(validate_config = TRUE) {
 
 sourceDataprocessorSubmodules <- function(ignore_newer_db_version = FALSE,
                                           source_submodule_functions = FALSE) {
-
   etlutils::runLevel2("Reset database lock from unfinished previous run", {
     etlutils::dbResetLock()
     etlutils::checkVersion(ignore_newer_db_version)
@@ -165,13 +161,11 @@ processData <- function(ignore_newer_db_version = FALSE, validate_config = TRUE)
   startDataprocessorModule(validate_config)
 
   try(etlutils::runLevel1("Run Dataprocessor", {
-
     sourceDataprocessorSubmodules(ignore_newer_db_version)
 
     etlutils::runLevel2("Run dataprocessor submodules", {
       runSubmodules()
     })
-
   }))
 
   # Reset lock and close all database connections. Do not surround this with runLevelX!
@@ -181,5 +175,4 @@ processData <- function(ignore_newer_db_version = FALSE, validate_config = TRUE)
   finish_message <- etlutils::generateFinishMessage()
 
   return(etlutils::finalize(finish_message))
-
 }

--- a/R-dataprocessor/dataprocessor/R/01_Shared_Functions.R
+++ b/R-dataprocessor/dataprocessor/R/01_Shared_Functions.R
@@ -30,7 +30,6 @@
 #'
 #' @export
 validateWardPhases <- function(timezone = GLOBAL_TIMEZONE) {
-
   msg_prefix <- "dataprocessor_config.toml: "
 
   ward_phases <- etlutils::getGlobalVariablesByPrefix("PHASES_WARD")

--- a/R-dataprocessor/dataprocessor/R/04_MRP_Recalculation.R
+++ b/R-dataprocessor/dataprocessor/R/04_MRP_Recalculation.R
@@ -18,7 +18,6 @@ recalculateMRPs <- function(start_date,
                             end_date = NULL,
                             ignore_newer_db_version = FALSE,
                             validate_config = TRUE) {
-
   start_date <- etlutils::as.POSIXctWithTimezone(start_date)
   end_date <- if (is.null(end_date)) {
     etlutils::as.POSIXctWithTimezone(Sys.Date())
@@ -231,7 +230,6 @@ recalculateMRPs <- function(start_date,
   etlutils::setSubmoduleName("MRPRecalculation")
 
   try(etlutils::runLevel1("Run additive MRP recalculation", {
-
     sourceDataprocessorSubmodules(
       ignore_newer_db_version = ignore_newer_db_version,
       source_submodule_functions = TRUE

--- a/R-dataprocessor/dataprocessor/tests/testthat/test-validateWardPhases.R
+++ b/R-dataprocessor/dataprocessor/tests/testthat/test-validateWardPhases.R
@@ -56,7 +56,6 @@ testthat::test_that("validateWardPhases rejects invalid keys", {
   assign("PHASES_WARD_1", c("ward_name = 'Station 1'", "phase_c_start = '2026-01-11 10:00:00'"), envir = .GlobalEnv)
   on.exit(rm(list = "PHASES_WARD_1", envir = .GlobalEnv), add = TRUE)
   testthat::expect_error(validateWardPhases(timezone = "UTC"), "Invalid subcondition")
-
 })
 
 # Rejects plus outside quoted values

--- a/R-dataprocessor/submodules/01_Study_1a/R-Study_1a/R/01_Create_Patient_And_Case_View.R
+++ b/R-dataprocessor/submodules/01_Study_1a/R-Study_1a/R/01_Create_Patient_And_Case_View.R
@@ -124,7 +124,6 @@ getLocationString <- function(encounters, locations) {
     encounters <- encounters[effective_physicaltype %in% c("ro", "bd")]
 
     if (nrow(encounters) > 0 && !all(is.na(encounters$enc_period_start))) {
-
       room_value <- NA_character_
       bed_value <- NA_character_
 
@@ -140,7 +139,6 @@ getLocationString <- function(encounters, locations) {
       col_name <- FRONTEND_DISPLAYED_ROOM_AND_BED_COLUMN
 
       if (startsWith(col_name, "loc_")) {
-
         if (!is.null(room_encounter)) {
           room_location_ref <- room_encounter[, enc_location_ref]
           room_location_id <- etlutils::fhirdataExtractIDs(room_location_ref)
@@ -158,7 +156,6 @@ getLocationString <- function(encounters, locations) {
           )
         }
       } else if (startsWith(col_name, "enc_")) {
-
         if (!is.null(room_encounter)) {
           room_value <- tryCatch(
             room_encounter[, get(col_name)],
@@ -226,7 +223,6 @@ getAdmissionDiagnoses <- function(encounter, conditions) {
 }
 
 getObservations <- function(encounters, query_datetime, obs_codes, obs_system, obs_by_pid = FALSE) {
-
   obs_codes <- parseQueryList(obs_codes)
   # Query template to get desired Observations from DB
   query_template <- paste0(
@@ -375,7 +371,6 @@ createFrontendTables <- function() {
   # based on the provided patient IDs per ward. It retrieves patient information from
   # the database and constructs the frontend table.
   createPatientFrontendTable <- function(patients, existing_record_ids) {
-
     pids <- unique(patients$pat_id)
     pids_count <- length(pids)
 
@@ -394,7 +389,6 @@ createFrontendTables <- function() {
 
     # Iterate over each unique patient ID to populate the frontend table
     for (i in seq_len(pids_count)) {
-
       patient <- patients[pat_id %in% pids[i]]
 
       # Get an existing record_id for the patient from the database patient_fe
@@ -524,7 +518,6 @@ createFrontendTables <- function() {
     enc_studyphase_at_admission <- etlutils::dbGetReadOnlyQuery(query, lock_id = "createEncounterFrontendTable()[3]")
 
     for (pid_index in seq_len(nrow(unique_pid_ward))) {
-
       pid <- unique_pid_ward$patient_id[pid_index]
       pid_ref <- etlutils::fhirdataGetPatientReference(pid)
       pid_main_encounters <- main_encounters[enc_patient_ref %in% pid_ref]
@@ -680,7 +673,6 @@ createFrontendTables <- function() {
               obs_weight$obs_valuequantity_unit
             )
           )
-
         }
         obs_height <- observations_height[obs_patient_ref %in% pid_ref]
         if (nrow(obs_height)) {
@@ -722,7 +714,6 @@ createFrontendTables <- function() {
         }
         data.table::set(enc_frontend_table, target_index, "redcap_repeat_instance", enc_redcap_repeat_instance)
       }
-
     }
     return(enc_frontend_table)
   }
@@ -776,8 +767,10 @@ createFrontendTables <- function() {
   getUniquePatientsRowWithNameIfExists <- function(patient_rows_from_database_for_single_pat_id) {
     pat_rows <- patient_rows_from_database_for_single_pat_id
     # Check if the column 'pat_name_use' exists and contains any "official" entries
-    if ("pat_name_use" %in% names(pat_rows) &&
-      any(pat_rows$pat_name_use %in% "official", na.rm = TRUE)) {
+    if (
+      "pat_name_use" %in% names(pat_rows) &&
+      any(pat_rows$pat_name_use %in% "official", na.rm = TRUE)
+    ) {
       # Filter rows where name is "official" and there is a non-empty, non-NA given name
       official_rows <- pat_rows[pat_name_use %in% "official" & pat_name_given != "" & !is.na(pat_name_given)]
       # If such official rows exist, return the one with the smallest patient_id
@@ -814,5 +807,4 @@ createFrontendTables <- function() {
     lock_id = "createFrontendTables()",
     stop_if_table_not_empty = TRUE
   )
-
 }

--- a/R-dataprocessor/submodules/02_MRP_Calculation/R-MRP_Calculation/R/00_Lib_MRP_Data_Preparation.R
+++ b/R-dataprocessor/submodules/02_MRP_Calculation/R-MRP_Calculation/R/00_Lib_MRP_Data_Preparation.R
@@ -149,7 +149,6 @@ getEncountersWithTimeRangeFromDB <- function(start_time, end_time) {
 # Load Einrichtungskontakt Encounters without retrolective MRP evaluation
 #
 getEncountersWithoutRetrolectiveMRPEvaluationFromDB <- function() {
-
   encounters_per_mrp_type <- list()
   #
   # 1.) Get all Einrichtungskontakt encounters that ended before now and do not
@@ -172,8 +171,7 @@ getEncountersWithoutRetrolectiveMRPEvaluationFromDB <- function() {
       "    SELECT enc_id FROM v_dp_mrp_calculations\n",
       "    WHERE mrp_calculation_type = '", mrp_type, "' AND study_phase = 'PhaseB'\n",
       "    GROUP BY enc_id\n",
-      "    HAVING COUNT(
-        meda_id) = 0\n",
+      "    HAVING COUNT(meda_id) = 0\n",
       "  )\n",
       ")"
     )
@@ -469,7 +467,6 @@ getMedicationStatementsFromDB <- function(patient_references) {
 # Medication (filtered by Medications with ATC)
 #
 getATCMedicationsFromDB <- function(medication_request, medication_administrations, medication_statements) {
-
   medication_ids <- etlutils::fhirdataExtractIDs(unique(c(
     medication_request$medreq_medicationreference_ref,
     medication_administrations$medadm_medicationreference_ref,
@@ -663,7 +660,6 @@ getConditionsFromDB <- function(patient_references) {
 # Extract ATC code of referenced Medication. If not exists then remove the resource.
 #
 appendATCColumns <- function(medication_resources, medications) {
-
   system_col <- grep("_medicationcodeableconcept_system$", names(medication_resources), value = TRUE)
   medication_resource_prefix <- sub("_medicationcodeableconcept_system$", "", system_col)
   code_col <- paste0(medication_resource_prefix, "_medicationcodeableconcept_code")
@@ -770,7 +766,6 @@ appendATCColumns <- function(medication_resources, medications) {
 #########################################
 
 getResourcesForMRPCalculation <- function(main_encounters) {
-
   if (!nrow(main_encounters)) {
     etlutils::catWarningMessage(paste0(
       "No Einrichtungskontakt encounters found that ended at least ",

--- a/R-dataprocessor/submodules/02_MRP_Calculation/R-MRP_Calculation/R/01_Lib_MRP_Calculation.R
+++ b/R-dataprocessor/submodules/02_MRP_Calculation/R-MRP_Calculation/R/01_Lib_MRP_Calculation.R
@@ -78,7 +78,6 @@ expandAndConcatenateICDs <- function(icd_column) {
     if (!grepl("+", icd, fixed = TRUE)) {
       # Handle single ICD code case
       return(paste(etlutils::expandICDs(icd), collapse = " "))
-
     }
     # Handle multiple ICD codes separated by '+'
     input_icds <- unlist(strsplit(icd, "\\+"))
@@ -87,7 +86,6 @@ expandAndConcatenateICDs <- function(icd_column) {
     # Create combinations and concatenate
     combinations <- outer(icd_1, icd_2, paste, sep = "+")
     return(trimws(paste(c(combinations), collapse = " ")))
-
   }
   # Apply the function to the entire column
   sapply(icd_column, processICD)
@@ -152,7 +150,6 @@ matchATCCodes <- function(active_atcs, mrp_table_list_by_atc) {
 #' Ergebnis-Spalte \code{output_col} enthalten sein sollen.
 #'
 computeATCForCalculation <- function(data_table, primary_col, inclusion_col, output_col, secondary_cols) {
-
   if (!(inclusion_col %in% names(data_table)) || !any(secondary_cols %in% names(data_table))) {
     data_table[, (output_col) := data_table[[primary_col]]]
     return(NULL)
@@ -254,7 +251,6 @@ matchATCCodePairs <- function(active_atcs, mrp_table_list_by_atc) {
 
           # There is no existing mrp in the result table with the same atc codes
           if (!length(duplicate_idx)) {
-
             mrp_index <- if (nrow(result_mrps) == 0) {
               1
             } else {
@@ -386,9 +382,7 @@ calculateMRPs <- function(start_date = NULL, end_date = NULL, return_used_resour
     )
 
     for (mrp_type in names(mrp_pair_lists)) {
-
       etlutils::runLevel3(paste0("Calculate ", mrp_type, " MRPs"), {
-
         mrp_pair_list <- mrp_pair_lists[[mrp_type]]
         mrp_pair_list_processed_content_hash <- mrp_pair_list$processed_content_hash
         mrp_pair_list <- mrp_pair_list$processed_content
@@ -523,8 +517,10 @@ calculateMRPs <- function(start_date = NULL, end_date = NULL, return_used_resour
                     kurzbeschr_suffix, "\n",
                     kurzbeschr_item2
                   )
-                  if ("kurzbeschr_additional" %in% names(collapsed_match) &&
-                    any(!is.na(kurzbeschr_additional))) {
+                  if (
+                    "kurzbeschr_additional" %in% names(collapsed_match) &&
+                    any(!is.na(kurzbeschr_additional))
+                  ) {
                     base <- paste(base, paste(kurzbeschr_additional, collapse = "\n"), sep = " ")
                   }
                   base

--- a/R-dataprocessor/submodules/02_MRP_Calculation/R-MRP_Calculation/R/02_Lib_MRP_Drug_Condition.R
+++ b/R-dataprocessor/submodules/02_MRP_Calculation/R-MRP_Calculation/R/02_Lib_MRP_Drug_Condition.R
@@ -110,7 +110,6 @@ matchICDCodes <- function(relevant_conditions, mrp_tables_by_icd, match_atc_code
 
   # Function to check if validity days match any patient Condition
   patientValidityDayMatches <- function(validity_days, patient_conditions, meda_datetime) {
-
     condition_start <- patient_conditions$start_datetime
     isresult <- FALSE
     if (!is.na(validity_days)) {
@@ -683,7 +682,6 @@ generateMatchDescriptionAbsoluteCutoff <- function(obs, loinc_mapping_table, pri
 #' @return A character string describing the match if the cutoff was met, otherwise `NA_character_`.
 #'
 matchLOINCCutoff <- function(observation_resources, match_proxy_row, loinc_mapping_table) {
-
   data.table::setorder(observation_resources, "start_datetime")
   match_description <- NA_character_
   cutoff_reference <- trimws(match_proxy_row$LOINC_CUTOFF_REFERENCE)
@@ -736,7 +734,6 @@ matchLOINCCutoff <- function(observation_resources, match_proxy_row, loinc_mappi
         )
 
         if (nrow(obs)) {
-
           obs <- filterObservations(
             obs = obs,
             reference_value_col = reference_value_col,
@@ -795,7 +792,6 @@ matchLOINCCutoff <- function(observation_resources, match_proxy_row, loinc_mappi
         obs <- data.table::fsetdiff(observation_resources, invalid_obs)
 
         if (nrow(obs)) {
-
           mapping_rows <- loinc_mapping_table[LOINC %in% obs$code]
           mapping_row  <- unique(mapping_rows[, c("LOINC_PRIMARY", "UNIT", "CONVERSION_FACTOR", "CONVERSION_UNIT")])
           if (nrow(mapping_row) == 1) { # no row would be an error and more than one row would be ambiguous
@@ -847,7 +843,6 @@ matchLOINCCutoff <- function(observation_resources, match_proxy_row, loinc_mappi
 
               # we must find any match and the last must be true
               if (any(match_found) && match_found[length(match_found)]) {
-
                 obs <- obs[match_found][, converted_value := obs_value_converted_to_threshold_unit[match_found]]
 
                 match_description <- generateMatchDescriptionAbsoluteCutoff(
@@ -955,7 +950,6 @@ matchICDProxies <- function(
   loinc_mapping_table = NULL,
   loinc_matching_function = NULL
 ) {
-
   all_matches <- list()
 
   matchProxy <- function(proxy_type, all_items, splitted_proxy_table) {
@@ -1023,7 +1017,6 @@ matchICDProxies <- function(
           # Select all items where the code matches any of the relevant secondary codes
           resources_with_proxy <- all_items[code %in% relevant_secondary_codes]
           if (nrow(resources_with_proxy)) {
-
             for (i in seq_len(nrow(match_proxy_rows))) {
               match_proxy_row <- match_proxy_rows[i]
               proxy_validity_days <- match_proxy_row[["ICD_PROXY_VALIDITY_DAYS"]]
@@ -1111,8 +1104,10 @@ matchICDProxies <- function(
     return(matched_rows)
   }
 
-  if (!is.null(medication_resources) &&
-    !is.null(drug_condition_mrp_tables_by_atc_proxy)) {
+  if (
+    !is.null(medication_resources) &&
+    !is.null(drug_condition_mrp_tables_by_atc_proxy)
+  ) {
     #  Combine all medication rows
     all_medications <- rbind(
       medication_resources$medication_requests[, .(
@@ -1135,8 +1130,10 @@ matchICDProxies <- function(
     all_matches[["ATC"]] <- atc_matches
   }
 
-  if (!is.null(procedure_resources) &&
-    !is.null(drug_condition_mrp_tables_by_ops_proxy)) {
+  if (
+    !is.null(procedure_resources) &&
+    !is.null(drug_condition_mrp_tables_by_ops_proxy)
+  ) {
     #  Combine all procedures rows
     all_procedures <- procedure_resources[, .(fhir_id = proc_id, code = proc_code_code, display = proc_code_display, start_datetime, end_datetime)]
     # OPS-Proxy-Matching
@@ -1148,10 +1145,12 @@ matchICDProxies <- function(
     all_matches[["OPS"]] <- ops_matches
   }
 
-  if (!is.null(observation_resources) &&
+  if (
+    !is.null(observation_resources) &&
     !is.null(drug_condition_mrp_tables_by_loinc_proxy) &&
     !is.null(loinc_matching_function) &&
-    !is.null(loinc_mapping_table)) {
+    !is.null(loinc_mapping_table)
+  ) {
     #  Combine all observation rows
     all_observations <- observation_resources[, .(
       fhir_id = obs_id,

--- a/R-dataprocessor/submodules/02_MRP_Calculation/R-MRP_Calculation/R/04_Calculate_Drug_Disease_MRPs.R
+++ b/R-dataprocessor/submodules/02_MRP_Calculation/R-MRP_Calculation/R/04_Calculate_Drug_Disease_MRPs.R
@@ -57,7 +57,6 @@ getCategoryDisplayDrugDisease <- function() {
 #'
 #' @export
 processExcelContentDrugDisease <- function(drug_disease_mrp_definition, mrp_type) {
-
   drug_disease_mrp_definition <- processExcelContentDrugCondition(drug_disease_mrp_definition, mrp_type)
 
   return(drug_disease_mrp_definition)

--- a/R-dataprocessor/submodules/02_MRP_Calculation/R-MRP_Calculation/R/07_Calculate_Drug_Niereninsuffizienz_MRPs.R
+++ b/R-dataprocessor/submodules/02_MRP_Calculation/R-MRP_Calculation/R/07_Calculate_Drug_Niereninsuffizienz_MRPs.R
@@ -50,7 +50,6 @@ getCategoryDisplayDrugNiereninsuffizienz <- function() {
 #'
 #' @return A cleaned and expanded data.table containing the MRP definition table.
 processExcelContentDrugNiereninsuffizienz <- function(drug_niereninsuffizienz_mrp_definition, mrp_type) {
-
   drug_niereninsuffizienz_mrp_definition <- processExcelContentDrugCondition(drug_niereninsuffizienz_mrp_definition, mrp_type)
 
   return(drug_niereninsuffizienz_mrp_definition)
@@ -72,7 +71,6 @@ processExcelContentDrugNiereninsuffizienz <- function(drug_niereninsuffizienz_mr
 #' }
 #'
 getSplittedMRPTablesDrugNiereninsuffizienz <- function(mrp_pair_list) {
-
   mrp_pair_list[, LOINC_VALIDITY_DAYS := if (!"LOINC_VALIDITY_DAYS" %in% names(mrp_pair_list)) NA_character_ else LOINC_VALIDITY_DAYS]
 
   splitted <- list(

--- a/R-dataprocessor/submodules/manual_start/MRP_Check/R-MRP_Check/R/00_Mrp_Check.R
+++ b/R-dataprocessor/submodules/manual_start/MRP_Check/R-MRP_Check/R/00_Mrp_Check.R
@@ -1,5 +1,4 @@
 mrpCheck <- function(start_date, end_date) {
-
   anonymizeTimestampsByPatient <- function(
     dt,
     patient_id_col = "FHIR Patient ID",
@@ -186,8 +185,7 @@ mrpCheck <- function(start_date, end_date) {
     )
 
     query <- paste0(
-      "SELECT MIN(
-        enc_period_start) AS min_enc_period_start\n",
+      "SELECT MIN(enc_period_start) AS min_enc_period_start\n",
       "FROM v_encounter_last_version\n",
       "WHERE enc_period_start BETWEEN '", start_date, "' AND '", end_date, "';"
     )
@@ -233,5 +231,4 @@ mrpCheck <- function(start_date, end_date) {
   etlutils::runLevel2("Save calculated MRPs as local Excel file", {
     etlutils::writeExcelFileGlobal(list("MRP Check" = result), "MRP_Check_Result_global")
   })
-
 }

--- a/R-dataprocessor/submodules/manual_start/MRP_Check/Start.R
+++ b/R-dataprocessor/submodules/manual_start/MRP_Check/Start.R
@@ -1,5 +1,4 @@
 etlutils::runLevel2("Calculate MRPs", {
-
   command_arguments <- NULL
 
   # # use this for debugging
@@ -21,5 +20,4 @@ etlutils::runLevel2("Calculate MRPs", {
   }
 
   mrpCheck(command_arguments$start_date, command_arguments$end_date)
-
 })

--- a/R-dataprocessor/submodules/manual_start/Statistical_Reports/R-Statistical_Reports/R/01_get-data.R
+++ b/R-dataprocessor/submodules/manual_start/Statistical_Reports/R-Statistical_Reports/R/01_get-data.R
@@ -466,8 +466,10 @@ getFallFeData <- function(lock_id, table_name) {
     dplyr::distinct() |>
     dplyr::arrange(record_id)
 
-  if (any(is.na(fall_fe_table$actual_fall_studienphase)) ||
-    any(fall_fe_table$actual_fall_studienphase == "PhaseBTest")) {
+  if (
+    any(is.na(fall_fe_table$actual_fall_studienphase)) ||
+    any(fall_fe_table$actual_fall_studienphase == "PhaseBTest")
+  ) {
     warning("The study phase from fall_fe contains NA or PhaseBTest values. These will be replaced with 'PhaseA'.
             For manual check compare fall_studienphase and actual_fall_studienphase in frontend_table in outpulLocal.")
 

--- a/R-db2frontend/db2frontend/R/00_Main.R
+++ b/R-db2frontend/db2frontend/R/00_Main.R
@@ -134,7 +134,6 @@ startFrontend2DB <- function(ignore_newer_db_version = FALSE, validate_config = 
   finish_message <- etlutils::generateFinishMessage()
 
   etlutils::finalize(finish_message)
-
 }
 
 
@@ -169,7 +168,6 @@ startDB2Frontend <- function(ignore_newer_db_version = FALSE, validate_config = 
     etlutils::runLevel2("Run Import Data from Database to Frontend", {
       importDB2Redcap()
     })
-
   }))
 
   # Reset lock and close all database connections. Do not surround this with runLevelX!
@@ -179,5 +177,4 @@ startDB2Frontend <- function(ignore_newer_db_version = FALSE, validate_config = 
   finish_message <- etlutils::generateFinishMessage()
 
   return(etlutils::finalize(finish_message))
-
 }

--- a/R-db2frontend/db2frontend/R/03_DB_To_Frontend.R
+++ b/R-db2frontend/db2frontend/R/03_DB_To_Frontend.R
@@ -14,7 +14,6 @@
 #' into REDCap and does not return a value.
 #'
 importDB2Redcap <- function() {
-
   tryRedcap <- function(redcap_process) {
     tryCatch(
       {
@@ -122,7 +121,6 @@ importDB2Redcap <- function() {
     data_to_import <- list()
     # Iterate over tables and columns to fetch and send data
     for (i in seq_along(table_names)) {
-
       table_name <- table_names[i]
 
       db_generated_id_col_name <- paste0(table_name, "_fe_id")
@@ -196,9 +194,7 @@ importDB2Redcap <- function() {
   })
 
   etlutils::runLevel2Line("Update data access groups", {
-
     if (exists("record_ids_with_data_access_group") && nrow(record_ids_with_data_access_group)) {
-
       ward_names <- unique(record_ids_with_data_access_group$fall_station)
 
       # Get all data access groups from Redcap
@@ -237,6 +233,5 @@ importDB2Redcap <- function() {
       # Set the data access groups in Redcap
       suppressWarnings(redcapAPI::importRecords(rcon = frontend_connection, data = record_ids_with_data_access_group))
     })
-
   })
 }

--- a/R-etlutils/etlutils/R/charlson_comorbidity_index.R
+++ b/R-etlutils/etlutils/R/charlson_comorbidity_index.R
@@ -127,7 +127,6 @@ addCharlsonScore <- function(table, caseIDColumnName, icdCodeColumnName, ageColu
   # Function to print the defined ICD codes list.
   # @param as_R_code If TRUE (default), the list is printed in R syntax; if FALSE, in a more human-readable format.
   printCodes <- function(as_R_code = TRUE) {
-
     getSubCodeListString <- function(mainCodesList, subCodeList, name, indentation, subCodeListIndex) {
       code <- unlist(subCodeList)
       indentation <- c(rep(" ", times = indentation))
@@ -249,7 +248,6 @@ addCharlsonScore <- function(table, caseIDColumnName, icdCodeColumnName, ageColu
 
 
     subCodesListIndex <- subCodesListIndex + 1
-
   }
 
   # for all rows with a diagnosis but without a cci score (from a high or relevant low risk diagnosis) -> set the cci score to 0

--- a/R-etlutils/etlutils/R/lib_config.R
+++ b/R-etlutils/etlutils/R/lib_config.R
@@ -22,7 +22,6 @@ parseStructuredConfigDefinitions <- function(
   allowed_key_pattern,
   allow_plus = FALSE
 ) {
-
   getNameOrIndex <- function(x, index) {
     x_names <- names(x)
     if (is.null(x_names) || length(x_names) < index || is.na(x_names[index]) || x_names[index] == "") {

--- a/R-etlutils/etlutils/R/lib_db.R
+++ b/R-etlutils/etlutils/R/lib_db.R
@@ -436,7 +436,6 @@ dbLock <- function(lock_id) {
 
     # decrease the recursive call counter 'db_lock_depth'
     .lib_db_env[[lock_id]] <- .lib_db_env[[lock_id]] - 1
-
   }
 }
 
@@ -694,7 +693,6 @@ dbCheckColumsWidthBeforeWrite <- function(table_name, table, allow_truncate = FA
   if (STOP) {
     stop("Some columns exceed their maximum allowed length (see error messages above).")
   }
-
 }
 
 dbGetReadOnlyColumns <- function(table_name) {

--- a/R-etlutils/etlutils/R/lib_fhir_search.R
+++ b/R-etlutils/etlutils/R/lib_fhir_search.R
@@ -218,7 +218,6 @@ fhirsearchResourcesByIDs <- function(
   parameters   = fhirsearchAddGlobalParams(c()),
   verbose      = 0
 ) {
-
   fhirsearchResourcesByIDs_get <- function(endpoint, resource, ids, parameters = NULL, verbose = 1) {
     # create a string of max_len of given maximal max_ids ids
     collect_ids_for_request <- function(ids, max_ids = length(ids), max_len = MAX_CHARACTER_LENGTH_FOR_GET_REQUESTS - MAX_CHARACTER_LENGTH_FOR_GET_REQUESTS_RESERVE) {
@@ -428,7 +427,6 @@ fhirsearchDownloadAndCrackResourcesByPIDs <- function(
   additional_search_parameter = NA,
   verbose = VERBOSE
 ) {
-
   WAIT_TIMES <- 2**(0:7)
   max_trials <- length(WAIT_TIMES)
 
@@ -516,7 +514,6 @@ fhirsearchDownloadAndCrackResourcesByPIDs <- function(
   resource_name <- table_description@resource
   # if there elements in pkg and at least one of them has a positive length
   while (0 < length(pkg) && any(0 < sapply(pkg, length))) {
-
     requests <- sapply(pkg, is.character)
     bndl_lengths <- if (0 < sum(requests)) {
       sum(sapply(pkg[requests], length))
@@ -695,7 +692,6 @@ fhirsearchResourcesByOwnID <- function(ids, table_description, last_updated = NA
   } else {
     # if there are no IDs -> create an empty table with all needed columns as character columns
     resource_table <- fhirdataCreateResourceTable(table_description)
-
   }
   return(resource_table)
 }
@@ -851,7 +847,6 @@ fhirsearchMultipleResourcesByPID <- function(pids_with_last_updated,
 
     # At this point, both Encounter and Patient resources have been loaded
     if (consider_patient_age && resource_name == "Encounter") {
-
       table_enc <- raw_fhir_resources[["Encounter"]][, c("enc_patient_ref", "enc_period_start")]
       table_pat <- raw_fhir_resources[["Patient"]][, c("pat_id", "pat_birthdate")]
       table_enc <- fhircrackr::fhir_rm_indices(table_enc, index_brackets)
@@ -878,7 +873,6 @@ fhirsearchMultipleResourcesByPID <- function(pids_with_last_updated,
 
       filtered_pids <- lapply(pids_with_last_updated, function(x) x[x %in% min_age_pat_ids])
       pids_with_last_updated <- Filter(function(x) length(x) > 0, filtered_pids)
-
     }
 
     resource_table <- raw_fhir_resources[[resource_name]]

--- a/R-etlutils/etlutils/R/lib_module.R
+++ b/R-etlutils/etlutils/R/lib_module.R
@@ -114,7 +114,6 @@ startModule <- function(config, hide_value_pattern = "") {
 #' @return This function does not return a value. It saves log data as a side effect.
 #'
 storeFinishData <- function(finish_message, error_message) {
-
   module_log <- data.table::data.table(
     module_name = as.character(dbGetModuleName()),
     message = as.character(finish_message),

--- a/R-etlutils/etlutils/R/lib_parallel.R
+++ b/R-etlutils/etlutils/R/lib_parallel.R
@@ -60,7 +60,6 @@ parallelNormalizeCoreNumber <- function(n_cores, max_cores = 0) {
 #'
 #' @export
 parallelGetAvailableCoreNumber <- function(os = NULL, max_cores = 0) {
-
   if (is.null(os)) {
     os <- parallelGetOperationSystem()
   }

--- a/R-etlutils/etlutils/R/lib_wrap_fhircrackr.R
+++ b/R-etlutils/etlutils/R/lib_wrap_fhircrackr.R
@@ -54,7 +54,6 @@ executeFHIRSearchVariation <- function(
   ))
 
   result <- if (!is.null(FHIR_TOKEN) && FHIR_TOKEN != "") {
-
     fhircrackr::fhir_search(
       request                = request,
       body                   = body,
@@ -66,7 +65,6 @@ executeFHIRSearchVariation <- function(
       delay_between_bundles  = delay_between_bundles
     )
   } else if (!is.null(FHIR_SERVER_USER) && !is.null(FHIR_SERVER_PASS) && FHIR_SERVER_USER != "" && FHIR_SERVER_PASS != "") {
-
     fhircrackr::fhir_search(
       request                = request,
       body                   = body,
@@ -79,7 +77,6 @@ executeFHIRSearchVariation <- function(
       delay_between_bundles  = delay_between_bundles
     )
   } else {
-
     fhircrackr::fhir_search(
       request                = request,
       body                   = body,

--- a/tools/check-style.R
+++ b/tools/check-style.R
@@ -5,7 +5,7 @@ if (!identical(diff_result, 0L)) {
   stop(
     paste(
       "R code is not formatted.",
-      "Run `Rscript tools/style.R`, review the diff, and commit the changes."
+      "Run `Rscript tools/style-full.R`, review the diff, and commit the changes."
     ),
     call. = FALSE
   )

--- a/tools/style-changed.R
+++ b/tools/style-changed.R
@@ -1,0 +1,87 @@
+findRepoRoot <- function(start_path = getwd()) {
+  current_path <- normalizePath(start_path, winslash = "/", mustWork = TRUE)
+
+  repeat {
+    if (dir.exists(file.path(current_path, ".git")) && file.exists(file.path(current_path, "tools", "style.R"))) {
+      return(current_path)
+    }
+
+    parent_path <- dirname(current_path)
+    if (identical(parent_path, current_path)) {
+      stop("Could not find the INTERPOLAR repository root above: ", start_path, call. = FALSE)
+    }
+
+    current_path <- parent_path
+  }
+}
+
+gitLines <- function(args) {
+  output <- system2("git", args, stdout = TRUE, stderr = FALSE)
+  if (identical(attr(output, "status"), 0L) || is.null(attr(output, "status"))) {
+    output[nzchar(output)]
+  } else {
+    character()
+  }
+}
+
+getMergeBase <- function(base_ref) {
+  output <- system2("git", c("merge-base", base_ref, "HEAD"), stdout = TRUE, stderr = FALSE)
+  if (identical(attr(output, "status"), 0L) || is.null(attr(output, "status"))) {
+    output[[1L]]
+  } else {
+    character()
+  }
+}
+
+changedFiles <- function(base_ref = Sys.getenv("INTERPOLAR_STYLE_BASE", "origin/develop")) {
+  merge_base <- getMergeBase(base_ref)
+  committed_files <- if (length(merge_base) == 1L && nzchar(merge_base)) {
+    gitLines(c("diff", "--name-only", "--diff-filter=ACMR", paste0(merge_base, "...HEAD")))
+  } else {
+    character()
+  }
+
+  all_changed_files <- unique(c(
+    committed_files,
+    gitLines(c("diff", "--name-only", "--diff-filter=ACMR")),
+    gitLines(c("diff", "--cached", "--name-only", "--diff-filter=ACMR"))
+  ))
+
+  all_changed_files[grepl("[.]R$", all_changed_files)]
+}
+
+isInStyleScope <- function(file_path, style_roots) {
+  normalized_file <- normalizePath(file_path, winslash = "/", mustWork = TRUE)
+  any(vapply(
+    style_roots,
+    function(style_root) startsWith(normalized_file, paste0(normalizePath(style_root, winslash = "/", mustWork = TRUE), "/")),
+    logical(1L)
+  ))
+}
+
+previous_wd <- getwd()
+repo_root <- findRepoRoot(previous_wd)
+old_autorun <- getOption("interpolar.style.autorun")
+
+on.exit(setwd(previous_wd), add = TRUE)
+on.exit(options(interpolar.style.autorun = old_autorun), add = TRUE)
+
+setwd(repo_root)
+options(interpolar.style.autorun = FALSE)
+source(file.path("tools", "style.R"))
+
+files_to_style <- changedFiles()
+files_to_style <- files_to_style[file.exists(files_to_style)]
+files_to_style <- files_to_style[vapply(files_to_style, isInStyleScope, logical(1L), existing_style_paths)]
+
+if (length(files_to_style) == 0L) {
+  message("No changed R files found in the configured style scope.")
+} else {
+  message("Formatting changed R files:")
+  invisible(lapply(files_to_style, function(file_path) {
+    message("  ", file_path)
+    styleFile(file_path)
+  }))
+}
+
+message("Restored working directory: ", previous_wd)

--- a/tools/style-current-file.R
+++ b/tools/style-current-file.R
@@ -1,0 +1,54 @@
+findInterpolarRoot <- function(start_path = getwd()) {
+  current_path <- normalizePath(start_path, winslash = "/", mustWork = TRUE)
+
+  repeat {
+    has_formatter <- file.exists(file.path(current_path, "tools", "style.R"))
+    has_editorconfig <- file.exists(file.path(current_path, ".editorconfig"))
+
+    if (has_formatter && has_editorconfig) {
+      return(current_path)
+    }
+
+    parent_path <- dirname(current_path)
+    if (identical(parent_path, current_path)) {
+      stop(
+        "Could not find the INTERPOLAR repository root above: ",
+        start_path,
+        call. = FALSE
+      )
+    }
+
+    current_path <- parent_path
+  }
+}
+
+getCurrentRStudioFile <- function() {
+  if (!requireNamespace("rstudioapi", quietly = TRUE) || !rstudioapi::isAvailable()) {
+    stop("`tools/style-current-file.R` must be run from RStudio.", call. = FALSE)
+  }
+
+  document_context <- rstudioapi::getActiveDocumentContext()
+  file_path <- document_context$path
+
+  if (!nzchar(file_path)) {
+    stop("The active RStudio document must be saved before it can be styled.", call. = FALSE)
+  }
+
+  normalizePath(file_path, winslash = "/", mustWork = TRUE)
+}
+
+previous_wd <- getwd()
+file_path <- getCurrentRStudioFile()
+repo_root <- findInterpolarRoot(dirname(file_path))
+old_autorun <- getOption("interpolar.style.autorun")
+
+on.exit(setwd(previous_wd), add = TRUE)
+on.exit(options(interpolar.style.autorun = old_autorun), add = TRUE)
+
+setwd(repo_root)
+options(interpolar.style.autorun = FALSE)
+source(file.path("tools", "style.R"))
+
+message("Formatting current file: ", file_path)
+styleFile(file_path)
+message("Restored working directory: ", previous_wd)

--- a/tools/style-current-package.R
+++ b/tools/style-current-package.R
@@ -1,0 +1,76 @@
+findInterpolarRoot <- function(start_path = getwd()) {
+  current_path <- normalizePath(start_path, winslash = "/", mustWork = TRUE)
+
+  repeat {
+    has_formatter <- file.exists(file.path(current_path, "tools", "style.R"))
+    has_editorconfig <- file.exists(file.path(current_path, ".editorconfig"))
+
+    if (has_formatter && has_editorconfig) {
+      return(current_path)
+    }
+
+    parent_path <- dirname(current_path)
+    if (identical(parent_path, current_path)) {
+      stop(
+        "Could not find the INTERPOLAR repository root above: ",
+        start_path,
+        call. = FALSE
+      )
+    }
+
+    current_path <- parent_path
+  }
+}
+
+findPackageRoot <- function(start_path = getwd()) {
+  current_path <- normalizePath(start_path, winslash = "/", mustWork = TRUE)
+
+  repeat {
+    if (file.exists(file.path(current_path, "DESCRIPTION"))) {
+      return(current_path)
+    }
+
+    parent_path <- dirname(current_path)
+    if (identical(parent_path, current_path)) {
+      stop(
+        "Could not find an R package DESCRIPTION above: ",
+        start_path,
+        call. = FALSE
+      )
+    }
+
+    current_path <- parent_path
+  }
+}
+
+getStartPath <- function() {
+  if (requireNamespace("rstudioapi", quietly = TRUE) && rstudioapi::isAvailable()) {
+    active_project <- rstudioapi::getActiveProject()
+    if (!is.null(active_project) && nzchar(active_project)) {
+      return(active_project)
+    }
+
+    document_context <- rstudioapi::getActiveDocumentContext()
+    if (nzchar(document_context$path)) {
+      return(dirname(document_context$path))
+    }
+  }
+
+  getwd()
+}
+
+previous_wd <- getwd()
+package_root <- findPackageRoot(getStartPath())
+repo_root <- findInterpolarRoot(package_root)
+old_autorun <- getOption("interpolar.style.autorun")
+
+on.exit(setwd(previous_wd), add = TRUE)
+on.exit(options(interpolar.style.autorun = old_autorun), add = TRUE)
+
+setwd(repo_root)
+options(interpolar.style.autorun = FALSE)
+source(file.path("tools", "style.R"))
+
+message("Formatting current package: ", package_root)
+stylePath(package_root)
+message("Restored working directory: ", previous_wd)

--- a/tools/style-full.R
+++ b/tools/style-full.R
@@ -1,0 +1,33 @@
+findInterpolarRoot <- function(start_path = getwd()) {
+  current_path <- normalizePath(start_path, winslash = "/", mustWork = TRUE)
+
+  repeat {
+    has_formatter <- file.exists(file.path(current_path, "tools", "style.R"))
+    has_editorconfig <- file.exists(file.path(current_path, ".editorconfig"))
+
+    if (has_formatter && has_editorconfig) {
+      return(current_path)
+    }
+
+    parent_path <- dirname(current_path)
+    if (identical(parent_path, current_path)) {
+      stop(
+        "Could not find the INTERPOLAR repository root above: ",
+        start_path,
+        call. = FALSE
+      )
+    }
+
+    current_path <- parent_path
+  }
+}
+
+previous_wd <- getwd()
+repo_root <- findInterpolarRoot(previous_wd)
+
+on.exit(setwd(previous_wd), add = TRUE)
+setwd(repo_root)
+
+message("Formatting complete INTERPOLAR R scope from: ", repo_root)
+source(file.path("tools", "style.R"))
+message("Restored working directory: ", previous_wd)

--- a/tools/style.R
+++ b/tools/style.R
@@ -145,14 +145,242 @@ normalizeShortDataTableListCalls <- function(file_path, width = 100L) {
   }
 }
 
+normalizeMultilineIfOpening <- function(file_path) {
+  lines <- readLines(file_path, warn = FALSE)
+  output <- character()
+  index <- 1L
+
+  while (index <= length(lines)) {
+    line <- lines[[index]]
+    next_line <- if (index < length(lines)) lines[[index + 1L]] else ""
+
+    if_match <- regexec("^(\\s*)if \\((.+(?:&&|\\|\\|)\\s*)$", line, perl = TRUE)
+    if_parts <- regmatches(line, if_match)[[1L]]
+
+    should_split <- length(if_parts) == 3L &&
+      grepl("^\\s+", next_line, perl = TRUE) &&
+      !grepl("^\\s*\\)", next_line, perl = TRUE)
+
+    if (should_split) {
+      indent <- if_parts[[2L]]
+      condition_start <- trimws(if_parts[[3L]])
+      output <- c(
+        output,
+        paste0(indent, "if ("),
+        paste0(indent, "  ", condition_start)
+      )
+    } else {
+      output <- c(output, line)
+    }
+
+    index <- index + 1L
+  }
+
+  if (!identical(lines, output)) {
+    writeLines(output, file_path, useBytes = TRUE)
+  }
+}
+
+removeBlankLinesAroundBraces <- function(file_path) {
+  lines <- readLines(file_path, warn = FALSE)
+  output <- character()
+
+  for (index in seq_along(lines)) {
+    line <- lines[[index]]
+    previous_line <- if (length(output)) output[[length(output)]] else ""
+    next_line <- if (index < length(lines)) lines[[index + 1L]] else ""
+    is_blank <- !nzchar(trimws(line))
+
+    should_drop <- is_blank &&
+      (
+        grepl("\\{\\s*$", previous_line, perl = TRUE) ||
+          grepl("^\\s*\\}+\\)*\\s*$", next_line, perl = TRUE)
+      )
+
+    if (!should_drop) {
+      output <- c(output, line)
+    }
+  }
+
+  if (!identical(lines, output)) {
+    writeLines(output, file_path, useBytes = TRUE)
+  }
+}
+
+stripQuotedText <- function(line) {
+  line <- gsub('"([^"\\\\]|\\\\.)*"', '""', line, perl = TRUE)
+  gsub("'([^'\\\\]|\\\\.)*'", "''", line, perl = TRUE)
+}
+
+parenBalance <- function(line) {
+  line_without_strings <- stripQuotedText(line)
+  opens <- gregexpr("(", line_without_strings, fixed = TRUE)[[1L]]
+  closes <- gregexpr(")", line_without_strings, fixed = TRUE)[[1L]]
+  open_count <- if (identical(opens, -1L)) 0L else length(opens)
+  close_count <- if (identical(closes, -1L)) 0L else length(closes)
+  open_count - close_count
+}
+
+removeLastClosingParen <- function(line) {
+  sub("\\)([^)]*)$", "\\1", line, perl = TRUE)
+}
+
+formatIfConditionLines <- function(condition_lines, indent) {
+  group_depth <- 0L
+  condition_indent <- paste0(indent, "  ")
+
+  vapply(condition_lines, function(condition_line) {
+    condition_line <- trimws(condition_line)
+    line_balance <- parenBalance(condition_line)
+    extra_indent <- if (group_depth > 0L) 2L * (group_depth + 1L) else 0L
+
+    if (startsWith(condition_line, "(") && line_balance > 0L) {
+      extra_indent <- extra_indent + 2L
+    }
+
+    group_depth <<- max(0L, group_depth + line_balance)
+    paste0(condition_indent, strrep(" ", extra_indent), condition_line)
+  }, character(1L), USE.NAMES = FALSE)
+}
+
+normalizeMultilineIfBlock <- function(file_path) {
+  lines <- readLines(file_path, warn = FALSE)
+  output <- character()
+  index <- 1L
+
+  while (index <= length(lines)) {
+    line <- lines[[index]]
+    if_match <- regexec("^(\\s*)if \\(\\s*$", line, perl = TRUE)
+    if_parts <- regmatches(line, if_match)[[1L]]
+
+    if (length(if_parts) != 2L || index == length(lines)) {
+      output <- c(output, line)
+      index <- index + 1L
+      next
+    }
+
+    indent <- if_parts[[2L]]
+    condition_lines <- character()
+    cursor <- index + 1L
+
+    while (cursor <= length(lines)) {
+      condition_line <- trimws(lines[[cursor]])
+
+      if (grepl("^\\)\\s*\\{\\s*$", condition_line, perl = TRUE)) {
+        break
+      }
+
+      if (grepl("\\)\\s*\\{\\s*$", condition_line, perl = TRUE)) {
+        condition_without_if_close <- trimws(removeLastClosingParen(trimws(sub("\\{\\s*$", "", condition_line, perl = TRUE))))
+        if (nzchar(condition_without_if_close)) {
+          condition_lines <- c(condition_lines, condition_without_if_close)
+        }
+        break
+      }
+
+      condition_lines <- c(condition_lines, condition_line)
+      cursor <- cursor + 1L
+    }
+
+    if (cursor <= length(lines) && length(condition_lines) > 0L) {
+      output <- c(
+        output,
+        paste0(indent, "if ("),
+        formatIfConditionLines(condition_lines, indent),
+        paste0(indent, ") {")
+      )
+      index <- cursor + 1L
+    } else {
+      output <- c(output, line)
+      index <- index + 1L
+    }
+  }
+
+  if (!identical(lines, output)) {
+    writeLines(output, file_path, useBytes = TRUE)
+  }
+}
+
 runPostProcessors <- function(style_path) {
   style_files <- list.files(style_path, pattern = "[.]R$", recursive = TRUE, full.names = TRUE)
   invisible(lapply(style_files, normalizeMultilineCallFirstArgument))
+  invisible(lapply(style_files, normalizeMultilineIfOpening))
+  invisible(lapply(style_files, normalizeMultilineIfBlock))
+  invisible(lapply(style_files, removeBlankLinesAroundBraces))
   invisible(lapply(style_files, normalizeShortSingleArgumentCalls))
   invisible(lapply(style_files, normalizeShortDataTableListCalls))
+  invisible(lapply(style_files, normalizeShortStringFunctionCalls))
 }
 
-styleProject <- function(style_path) {
+normalizeShortStringFunctionCalls <- function(file_path, width = 100L) {
+  lines <- readLines(file_path, warn = FALSE)
+  output <- character()
+  index <- 1L
+
+  while (index <= length(lines)) {
+    line <- lines[[index]]
+    next_line <- if (index < length(lines)) lines[[index + 1L]] else ""
+
+    open_match <- regexec('^(\\s*)"([^"]*\\()\\s*$', line, perl = TRUE)
+    continuation_match <- regexec('^\\s*([^"]*\\)[^"]*)"(.*)$', next_line, perl = TRUE)
+
+    open_parts <- regmatches(line, open_match)[[1L]]
+    continuation_parts <- regmatches(next_line, continuation_match)[[1L]]
+    collapsed_line <- if (length(open_parts) == 3L && length(continuation_parts) == 3L) {
+      paste0(open_parts[[2L]], '"', open_parts[[3L]], trimws(continuation_parts[[2L]]), '"', continuation_parts[[3L]])
+    } else {
+      ""
+    }
+
+    should_collapse <- length(open_parts) == 3L &&
+      length(continuation_parts) == 3L &&
+      nchar(collapsed_line, type = "width") <= width
+
+    if (should_collapse) {
+      output <- c(output, collapsed_line)
+      index <- index + 2L
+    } else {
+      output <- c(output, line)
+      index <- index + 1L
+    }
+  }
+
+  if (!identical(lines, output)) {
+    writeLines(output, file_path, useBytes = TRUE)
+  }
+}
+
+styleFile <- function(file_path) {
+  styler::style_file(
+    path = file_path,
+    transformers = style_transformer,
+    include_roxygen_examples = FALSE
+  )
+
+  normalizeMultilineCallFirstArgument(file_path)
+  normalizeMultilineIfOpening(file_path)
+  normalizeMultilineIfBlock(file_path)
+  removeBlankLinesAroundBraces(file_path)
+  normalizeShortSingleArgumentCalls(file_path)
+  normalizeShortDataTableListCalls(file_path)
+  normalizeShortStringFunctionCalls(file_path)
+
+  styler::style_file(
+    path = file_path,
+    transformers = style_transformer,
+    include_roxygen_examples = FALSE
+  )
+
+  normalizeMultilineCallFirstArgument(file_path)
+  normalizeMultilineIfOpening(file_path)
+  normalizeMultilineIfBlock(file_path)
+  removeBlankLinesAroundBraces(file_path)
+  normalizeShortSingleArgumentCalls(file_path)
+  normalizeShortDataTableListCalls(file_path)
+  normalizeShortStringFunctionCalls(file_path)
+}
+
+stylePath <- function(style_path) {
   styler::style_dir(
     path = style_path,
     recursive = TRUE,
@@ -174,4 +402,6 @@ styleProject <- function(style_path) {
   runPostProcessors(style_path)
 }
 
-invisible(lapply(existing_style_paths, styleProject))
+if (isTRUE(getOption("interpolar.style.autorun", TRUE))) {
+  invisible(lapply(existing_style_paths, stylePath))
+}


### PR DESCRIPTION
## Summary
- add RStudio-friendly wrappers for formatting the full INTERPOLAR R scope, changed R files, the current file, or the current package
- make tools/style-full.R robust when started from the repository root or any subdirectory, and remove the redundant style-interpolar wrapper
- expose reusable styleFile/stylePath helpers from tools/style.R
- keep short SQL-style function calls inside strings on one line when they fit the configured width
- normalize multiline if conditions so nested groups keep the expected additional indentation
- remove redundant blank lines directly after opening braces and directly before closing braces

## Verification
- Rscript tools/style-changed.R
- Rscript tools/style-current-package.R from R-cds2db/cds2db
- Rscript tools/style-full.R from repository root
- Rscript ../../tools/style-full.R from R-cds2db/cds2db
- Rscript tools/check-style.R
- parse changed R files
- git diff --check