### PR TITLE
Improve CDS-HUB SQL generation workflow

### DIFF
--- a/Postgres-cds_hub/SQL_development.md
+++ b/Postgres-cds_hub/SQL_development.md
@@ -121,6 +121,10 @@ bash Postgres-cds_hub/generate-sql.sh
 cp -R Postgres-cds_hub/generated/sql/. Postgres-cds_hub/sql/
 ```
 
+Der Generator übernimmt bei unverändertem SQL-Inhalt die bestehenden Header der
+versionierten Datei. Reine Änderungen an volatilen Header-Metadaten wie
+`Create time` erzeugen dadurch beim Kopieren keine Git-Diffs.
+
 Danach sollten die Änderungen an Templates, Excel-Dateien und den erzeugten
 SQL-Dateien gemeinsam committed werden.
 

--- a/Postgres-cds_hub/generate-sql.sh
+++ b/Postgres-cds_hub/generate-sql.sh
@@ -31,6 +31,52 @@ copy_manual_base_sql() {
   done
 }
 
+normalize_generated_sql() {
+  sed \
+    -e '/^-- Create time:/d' \
+    -e '/^-- Rights definition file last update :/d' \
+    -e '/^-- Rights definition file size        :/d' \
+    "$1"
+}
+
+preserve_header_only_unchanged_file() {
+  local source_file="$1"
+  local generated_file="$2"
+
+  [ -f "$source_file" ] || return 0
+  [ -f "$generated_file" ] || return 0
+
+  if cmp -s "$source_file" "$generated_file"; then
+    return 0
+  fi
+
+  if diff -q \
+    <(normalize_generated_sql "$source_file") \
+    <(normalize_generated_sql "$generated_file") >/dev/null; then
+    cp "$source_file" "$generated_file"
+  fi
+}
+
+preserve_header_only_unchanged_generated_sql() {
+  local source_dir="$1"
+  local generated_dir="$2"
+
+  while IFS= read -r -d '' generated_file; do
+    local relative_path="${generated_file#${generated_dir}/}"
+    preserve_header_only_unchanged_file \
+      "${source_dir}/${relative_path}" \
+      "$generated_file"
+  done < <(
+    find "$generated_dir" -type f -name '*.sql' -print0 |
+      while IFS= read -r -d '' sql_file; do
+        if head -n 5 "$sql_file" | grep -q "This file is generated"; then
+          printf '%s\0' "$sql_file"
+        fi
+      done |
+      sort -z
+  )
+}
+
 rm -rf "$tmp_sql_dir"
 mkdir -p "$tmp_sql_dir"
 
@@ -58,5 +104,7 @@ if command -v pg_format >/dev/null 2>&1; then
 else
   echo "Generated SQL was not formatted because pg_format is not installed." >&2
 fi
+
+preserve_header_only_unchanged_generated_sql "$source_sql_dir" "$target_sql_dir"
 
 echo "Generated CDS-HUB SQL scripts in ${target_sql_dir}"


### PR DESCRIPTION
## Zusammenfassung
- stabilisiert den CDS-HUB SQL-Generator inklusive mehrzeiliger IF-Templates
- ergänzt SQL-Format- und Generator-Drift-Checks in GitHub Actions
- dokumentiert den SQL-Entwicklungsworkflow für manuelle und generierte Skripte
- hält Docker beim versionierten SQL-Stand und vermeidet Generator-/Formatter-Tooling im Runtime-Image
- verhindert Header-only-Diffs beim lokalen Generator-/Übernahmeprozess

## Tests
- bash -n Postgres-cds_hub/generate-sql.sh tools/check-generated-sql.sh tools/format-sql.sh tools/check-sql-format.sh tools/install-pgformatter.sh
- git diff --check
- docker compose config --quiet
- tools/detect-sql-checks.sh mit Beispielpfaden
- bash Postgres-cds_hub/generate-sql.sh
- simuliertes Kopieren von generated/sql nach sql erzeugt keinen Header-only-Diff
- tools/check-generated-sql.sh
- Docker Smoke-Test mit frischer cds_hub DB und start.sql