### PR TITLE
Resolve Medication reference chains recursively

### DIFF
--- a/Database_Snapshot.md
+++ b/Database_Snapshot.md
@@ -249,10 +249,13 @@ Auswertungsspalten:
   LOINC-Mapping-Datei. Nicht gemappte oder Nicht-LOINC-Zeilen bleiben erhalten
   und erhalten in den Zusatzspalten leere Werte.
 - `medicationrequest`, `medicationadministration` und `medicationstatement`
-  erhalten die Code-/System-Paare der direkt referenzierten `Medication`.
-  Mehrere unterschiedliche Paare erzeugen entsprechend mehrere Ausgabezeilen.
-  Referenzen ohne gefundenes Paar bleiben erhalten und erscheinen im
-  Enrichment-Review.
+  erhalten die Code-/System-Paare aller `Medication`-Einträge, die über die
+  direkte Referenz und rekursiv über
+  `med_ingredient_itemreference_ref` erreichbar sind. Mehrere unterschiedliche
+  Paare erzeugen entsprechend mehrere Ausgabezeilen; Duplikate werden entfernt.
+  Auch zyklische Referenzen werden sicher beendet. Fehlende referenzierte
+  Medications und Referenzketten ohne erreichbaren Code bleiben erhalten und
+  erscheinen im Enrichment-Review.
 
 Das Alter wird in abgeschlossenen Jahren berechnet. Neu ergänzte Altersspalten
 stehen am Ende der Tabelle. Die bereits vorhandene Spalte `fall_bmi` wird nicht

--- a/Database_Snapshot.md
+++ b/Database_Snapshot.md
@@ -257,6 +257,11 @@ Auswertungsspalten:
   Medications und Referenzketten ohne erreichbaren Code bleiben erhalten und
   erscheinen im Enrichment-Review.
 
+Die Medication-Auflösung wird für die vereinigten Referenzen aus Request,
+Statement und Administration einmal je Snapshot-Variante vorbereitet und über
+eine temporäre, indexierte PostgreSQL-Tabelle wiederverwendet. Sie wird nicht
+für jeden Chunk oder jede Quelltabelle erneut berechnet.
+
 Das Alter wird in abgeschlossenen Jahren berechnet. Neu ergänzte Altersspalten
 stehen am Ende der Tabelle. Die bereits vorhandene Spalte `fall_bmi` wird nicht
 verschoben.

--- a/R-cdstoolchain/pseudonym/R/enrich_medication_reference.R
+++ b/R-cdstoolchain/pseudonym/R/enrich_medication_reference.R
@@ -21,6 +21,11 @@ SNAPSHOT_MEDICATION_REFERENCE_SPECS <- data.table::data.table(
   )
 )
 
+SNAPSHOT_MEDICATION_INGREDIENT_REFERENCE_COLUMN <-
+  "med_ingredient_itemreference_ref"
+SNAPSHOT_MEDICATION_REFERENCE_ISSUES_COLUMN <-
+  ".snapshot_medication_reference_issues"
+
 extractMedicationReferenceId <- function(references) {
   references <- as.character(references)
   references[is.na(references) | !nzchar(references)] <- NA_character_
@@ -35,6 +40,8 @@ emptyMedicationReferenceReport <- function() {
     REFERENCE_COLUMN = character(),
     REFERENCE_VALUE = character(),
     MEDICATION_ID = character(),
+    ISSUE_TYPE = character(),
+    RELATED_MEDICATION_ID = character(),
     N = integer()
   )
 }
@@ -74,24 +81,55 @@ aggregateMedicationReferenceReport <- function(report) {
       "TABLE_NAME",
       "REFERENCE_COLUMN",
       "REFERENCE_VALUE",
-      "MEDICATION_ID"
+      "MEDICATION_ID",
+      "ISSUE_TYPE",
+      "RELATED_MEDICATION_ID"
     ),
     value_column = "N",
     result_column = "N"
   )
 }
 
-getUnmatchedMedicationReferencesFromEnrichedTable <- function(table, table_name, spec) {
+getUnmatchedMedicationReferencesFromEnrichedTable <- function(
+  table,
+  table_name,
+  spec
+) {
   reference_column <- spec[["reference_column"]]
   system_column <- spec[["system_column"]]
   code_column <- spec[["code_column"]]
-  required_columns <- c(reference_column, system_column, code_column)
-  if (!all(required_columns %in% names(table)) || nrow(table) == 0) {
+  if (!reference_column %in% names(table) || nrow(table) == 0) {
     return(emptyMedicationReferenceReport())
   }
 
   references <- as.character(table[[reference_column]])
   medication_ids <- extractMedicationReferenceId(references)
+  if (SNAPSHOT_MEDICATION_REFERENCE_ISSUES_COLUMN %in% names(table)) {
+    issue_values <- as.character(table[[SNAPSHOT_MEDICATION_REFERENCE_ISSUES_COLUMN]])
+    issue_rows <- which(!is.na(issue_values) & nzchar(issue_values))
+    reports <- lapply(issue_rows, function(row_index) {
+      issues <- strsplit(issue_values[row_index], "\n", fixed = TRUE)[[1]]
+      issue_parts <- strsplit(issues, "\t", fixed = TRUE)
+      data.table::data.table(
+        TABLE_NAME = table_name,
+        REFERENCE_COLUMN = reference_column,
+        REFERENCE_VALUE = references[row_index],
+        MEDICATION_ID = medication_ids[row_index],
+        ISSUE_TYPE = vapply(issue_parts, `[`, character(1), 1),
+        RELATED_MEDICATION_ID = vapply(issue_parts, `[`, character(1), 2),
+        N = 1L
+      )
+    })
+    if (length(reports) == 0) {
+      return(emptyMedicationReferenceReport())
+    }
+    return(aggregateMedicationReferenceReport(data.table::rbindlist(reports)))
+  }
+
+  required_code_columns <- c(system_column, code_column)
+  if (!all(required_code_columns %in% names(table))) {
+    return(emptyMedicationReferenceReport())
+  }
   unmatched_rows <- !is.na(medication_ids) &
     nzchar(medication_ids) &
     (
@@ -104,14 +142,24 @@ getUnmatchedMedicationReferencesFromEnrichedTable <- function(table, table_name,
     return(emptyMedicationReferenceReport())
   }
 
-  report <- data.table::data.table(
+  aggregateMedicationReferenceReport(data.table::data.table(
     TABLE_NAME = table_name,
     REFERENCE_COLUMN = reference_column,
     REFERENCE_VALUE = references[unmatched_rows],
     MEDICATION_ID = medication_ids[unmatched_rows],
+    ISSUE_TYPE = "no_reachable_code",
+    RELATED_MEDICATION_ID = medication_ids[unmatched_rows],
     N = 1L
+  ))
+}
+
+aggregateMedicationReferenceSummary <- function(summary) {
+  sumDataTableColumnBy(
+    summary,
+    group_columns = c("TABLE_NAME", "REFERENCE_COLUMN", "ISSUE_TYPE"),
+    value_column = "UNMATCHED_ROWS",
+    result_column = "UNMATCHED_ROWS"
   )
-  aggregateMedicationReferenceReport(report)
 }
 
 newBoundedMedicationReferenceReview <- function(detail_limit = 1000L) {
@@ -124,6 +172,7 @@ newBoundedMedicationReferenceReview <- function(detail_limit = 1000L) {
   context$summary <- data.table::data.table(
     TABLE_NAME = character(),
     REFERENCE_COLUMN = character(),
+    ISSUE_TYPE = character(),
     UNMATCHED_ROWS = numeric()
   )
   context$examples <- emptyMedicationReferenceReport()
@@ -137,24 +186,13 @@ recordBoundedMedicationReferenceReview <- function(context, report) {
 
   chunk_summary <- sumDataTableColumnBy(
     report,
-    group_columns = c("TABLE_NAME", "REFERENCE_COLUMN"),
+    group_columns = c("TABLE_NAME", "REFERENCE_COLUMN", "ISSUE_TYPE"),
     value_column = "N",
     result_column = "UNMATCHED_ROWS"
   )
-  for (i in seq_len(nrow(chunk_summary))) {
-    matching_row <- context$summary[["TABLE_NAME"]] == chunk_summary[["TABLE_NAME"]][i] &
-      context$summary[["REFERENCE_COLUMN"]] == chunk_summary[["REFERENCE_COLUMN"]][i]
-    if (any(matching_row)) {
-      context$summary[["UNMATCHED_ROWS"]][matching_row] <-
-        context$summary[["UNMATCHED_ROWS"]][matching_row] +
-        chunk_summary[["UNMATCHED_ROWS"]][i]
-    } else {
-      context$summary <- data.table::rbindlist(list(
-        context$summary,
-        chunk_summary[i, ]
-      ))
-    }
-  }
+  context$summary <- aggregateMedicationReferenceSummary(
+    data.table::rbindlist(list(context$summary, chunk_summary))
+  )
 
   remaining_examples <- context$detail_limit - nrow(context$examples)
   if (remaining_examples > 0) {
@@ -167,7 +205,21 @@ recordBoundedMedicationReferenceReview <- function(context, report) {
 }
 
 finalizeBoundedMedicationReferenceReview <- function(context) {
-  data.table::setorderv(context$summary, c("TABLE_NAME", "REFERENCE_COLUMN"))
+  data.table::setorderv(
+    context$summary,
+    c("TABLE_NAME", "REFERENCE_COLUMN", "ISSUE_TYPE")
+  )
+  data.table::setorderv(
+    context$examples,
+    c(
+      "TABLE_NAME",
+      "REFERENCE_COLUMN",
+      "ISSUE_TYPE",
+      "MEDICATION_ID",
+      "RELATED_MEDICATION_ID",
+      "REFERENCE_VALUE"
+    )
+  )
   list(
     summary = context$summary[],
     unmatched_reference_examples = context$examples[]

--- a/R-cdstoolchain/pseudonym/R/pseudonymize_snapshot_db.R
+++ b/R-cdstoolchain/pseudonym/R/pseudonymize_snapshot_db.R
@@ -366,7 +366,32 @@ pseudonymizeSnapshotDatabase <- function(
   )
 
   snapshotEnsureSchema(target_connection, target_table_schema)
-  streaming_context <- newSnapshotStreamingContext(input_repo_path)
+  medication_resolution_tables <- list()
+  runPseudonymizationLogStep(2L,
+    "Prepare shared Medication reference resolution",
+    {
+      medication_resolution_tables <- prepareSnapshotMedicationResolutionTables(
+        connection = source_connection,
+        materialization_plan = result[["materialization_plan"]],
+        rules = result[["rules"]],
+        source_schema = source_schema,
+        source_view_prefix = source_view_prefix,
+        last_version_suffix = last_version_suffix
+      )
+    },
+    log_steps = log_steps
+  )
+  on.exit(
+    dropSnapshotMedicationResolutionTables(
+      source_connection,
+      medication_resolution_tables
+    ),
+    add = TRUE
+  )
+  streaming_context <- newSnapshotStreamingContext(
+    input_repo_path,
+    medication_resolution_tables
+  )
   summary_rows <- list()
   write_summary_rows <- list()
   runPseudonymizationLogStep(2L,

--- a/R-cdstoolchain/pseudonym/R/pseudonymize_snapshot_streaming.R
+++ b/R-cdstoolchain/pseudonym/R/pseudonymize_snapshot_streaming.R
@@ -52,6 +52,14 @@ snapshotNormalizedReferenceExpression <- function(
   )
 }
 
+indentSql <- function(sql, spaces = 2L) {
+  indentation <- strrep(" ", spaces)
+  paste0(
+    indentation,
+    gsub("\n", paste0("\n", indentation), sql, fixed = TRUE)
+  )
+}
+
 buildSnapshotMedicationResolutionQuery <- function(
   connection,
   source_root_queries,
@@ -81,16 +89,16 @@ buildSnapshotMedicationResolutionQuery <- function(
     paste0(
       "SELECT DISTINCT ", quoted_med_id,
       "::text AS source_medication_id,\n",
-      normalized_ingredient_reference, " AS target_medication_id\n",
+      "  ", normalized_ingredient_reference, " AS target_medication_id\n",
       "FROM ", medication_relation, "\n",
       "WHERE NULLIF(", quoted_med_id, "::text, '') IS NOT NULL\n",
-      "AND ", normalized_ingredient_reference, " IS NOT NULL"
+      "  AND ", normalized_ingredient_reference, " IS NOT NULL"
     )
   }
   source_roots_query <- paste(
     "SELECT DISTINCT root_medication_id",
     "FROM (",
-    paste(source_root_queries, collapse = "\nUNION ALL\n"),
+    indentSql(paste(source_root_queries, collapse = "\nUNION ALL\n")),
     ") medication_root_candidates",
     "WHERE root_medication_id IS NOT NULL",
     sep = "\n"
@@ -101,48 +109,48 @@ buildSnapshotMedicationResolutionQuery <- function(
     # UNION deduplicates every root/node pair, so cycles terminate naturally.
     "UNION",
     "SELECT medication_walk.root_medication_id,",
-    "medication_edges.target_medication_id",
+    "  medication_edges.target_medication_id",
     "FROM medication_walk",
     "JOIN medication_edges",
-    "ON medication_edges.source_medication_id = medication_walk.medication_id",
+    "  ON medication_edges.source_medication_id = medication_walk.medication_id",
     sep = "\n"
   )
   medication_code_values_query <- paste0(
     "SELECT DISTINCT medication_walk.root_medication_id,\n",
-    "medication.", quoted_med_system, " AS medication_system,\n",
-    "medication.", quoted_med_code, " AS medication_code\n",
+    "  medication.", quoted_med_system, " AS medication_system,\n",
+    "  medication.", quoted_med_code, " AS medication_code\n",
     "FROM medication_walk\n",
     "JOIN ", medication_relation, " medication\n",
-    "ON medication.", quoted_med_id,
+    "  ON medication.", quoted_med_id,
     "::text = medication_walk.medication_id\n",
     "WHERE NULLIF(medication.", quoted_med_system,
     "::text, '') IS NOT NULL\n",
-    "AND NULLIF(medication.", quoted_med_code, "::text, '') IS NOT NULL"
+    "  AND NULLIF(medication.", quoted_med_code, "::text, '') IS NOT NULL"
   )
   medication_codes_query <- paste(
     "SELECT root_medication_id, medication_system, medication_code,",
-    "row_number() OVER (",
-    "  PARTITION BY root_medication_id",
-    "  ORDER BY medication_system, medication_code",
-    ") AS code_number",
+    "  row_number() OVER (",
+    "    PARTITION BY root_medication_id",
+    "    ORDER BY medication_system, medication_code",
+    "  ) AS code_number",
     "FROM medication_code_values",
     sep = "\n"
   )
   medication_issues_query <- paste(
     "SELECT DISTINCT medication_walk.root_medication_id,",
-    "'missing_medication'::text AS issue_type,",
-    "medication_walk.medication_id AS related_medication_id",
+    "  'missing_medication'::text AS issue_type,",
+    "  medication_walk.medication_id AS related_medication_id",
     "FROM medication_walk",
     "LEFT JOIN medication_nodes",
-    "ON medication_nodes.medication_id = medication_walk.medication_id",
+    "  ON medication_nodes.medication_id = medication_walk.medication_id",
     "WHERE medication_nodes.medication_id IS NULL",
     "UNION",
     "SELECT source_roots.root_medication_id,",
-    "'no_reachable_code'::text AS issue_type,",
-    "source_roots.root_medication_id AS related_medication_id",
+    "  'no_reachable_code'::text AS issue_type,",
+    "  source_roots.root_medication_id AS related_medication_id",
     "FROM source_roots",
     "JOIN medication_nodes",
-    "ON medication_nodes.medication_id = source_roots.root_medication_id",
+    "  ON medication_nodes.medication_id = source_roots.root_medication_id",
     "WHERE NOT EXISTS (",
     "  SELECT 1",
     "  FROM medication_code_values",
@@ -155,33 +163,53 @@ buildSnapshotMedicationResolutionQuery <- function(
   )
   medication_issue_summary_query <- paste(
     "SELECT root_medication_id,",
-    "string_agg(",
-    "  issue_type || E'\\t' || related_medication_id,",
-    "  E'\\n' ORDER BY issue_type, related_medication_id",
-    ") AS issues",
+    "  string_agg(",
+    "    issue_type || E'\\t' || related_medication_id,",
+    "    E'\\n' ORDER BY issue_type, related_medication_id",
+    "  ) AS issues",
     "FROM medication_issues",
     "GROUP BY root_medication_id",
     sep = "\n"
   )
   ctes <- c(
-    paste0("medication_nodes AS (\n", medication_nodes_query, "\n)"),
-    paste0("medication_edges AS (\n", medication_edges_query, "\n)"),
-    paste0("source_roots AS (\n", source_roots_query, "\n)"),
+    paste0(
+      "medication_nodes AS (\n",
+      indentSql(medication_nodes_query),
+      "\n)"
+    ),
+    paste0(
+      "medication_edges AS (\n",
+      indentSql(medication_edges_query),
+      "\n)"
+    ),
+    paste0(
+      "source_roots AS (\n",
+      indentSql(source_roots_query),
+      "\n)"
+    ),
     paste0(
       "medication_walk(root_medication_id, medication_id) AS (\n",
-      medication_walk_query,
+      indentSql(medication_walk_query),
       "\n)"
     ),
     paste0(
       "medication_code_values AS (\n",
-      medication_code_values_query,
+      indentSql(medication_code_values_query),
       "\n)"
     ),
-    paste0("medication_codes AS (\n", medication_codes_query, "\n)"),
-    paste0("medication_issues AS (\n", medication_issues_query, "\n)"),
+    paste0(
+      "medication_codes AS (\n",
+      indentSql(medication_codes_query),
+      "\n)"
+    ),
+    paste0(
+      "medication_issues AS (\n",
+      indentSql(medication_issues_query),
+      "\n)"
+    ),
     paste0(
       "medication_issue_summary AS (\n",
-      medication_issue_summary_query,
+      indentSql(medication_issue_summary_query),
       "\n)"
     )
   )
@@ -189,16 +217,19 @@ buildSnapshotMedicationResolutionQuery <- function(
     "WITH RECURSIVE\n",
     paste(ctes, collapse = ",\n"),
     "\nSELECT source_roots.root_medication_id,\n",
-    "medication_codes.medication_system,\n",
-    "medication_codes.medication_code,\n",
+    "  medication_codes.medication_system,\n",
+    "  medication_codes.medication_code,\n",
     # Issues are stored once per root, not once per resolved code.
-    "CASE WHEN COALESCE(medication_codes.code_number, 1) = 1 ",
-    "THEN medication_issue_summary.issues ELSE NULL END AS issues\n",
+    "  CASE WHEN COALESCE(medication_codes.code_number, 1) = 1\n",
+    "    THEN medication_issue_summary.issues\n",
+    "    ELSE NULL\n",
+    "  END AS issues\n",
     "FROM source_roots\n",
     "LEFT JOIN medication_codes\n",
-    "ON medication_codes.root_medication_id = source_roots.root_medication_id\n",
+    "  ON medication_codes.root_medication_id = source_roots.root_medication_id\n",
     "LEFT JOIN medication_issue_summary\n",
-    "ON medication_issue_summary.root_medication_id = source_roots.root_medication_id"
+    "  ON medication_issue_summary.root_medication_id = ",
+    "source_roots.root_medication_id"
   )
 }
 
@@ -247,10 +278,13 @@ buildSnapshotMedicationSourceQuery <- function(
 
   paste0(
     "SELECT ",
-    paste(c(source_columns, enrichment_select, issue_select), collapse = ",\n"),
+    paste(
+      c(source_columns, enrichment_select, issue_select),
+      collapse = ",\n  "
+    ),
     "\nFROM ", source_relation, " ", source_alias, "\n",
     "LEFT JOIN ", medication_resolution_relation, " ", resolution_alias, "\n",
-    "ON ", resolution_alias, ".root_medication_id = ", normalized_reference
+    "  ON ", resolution_alias, ".root_medication_id = ", normalized_reference
   )
 }
 

--- a/R-cdstoolchain/pseudonym/R/pseudonymize_snapshot_streaming.R
+++ b/R-cdstoolchain/pseudonym/R/pseudonymize_snapshot_streaming.R
@@ -45,7 +45,9 @@ buildSnapshotMedicationSourceQuery <- function(
   source_fields,
   medication_relation,
   spec,
-  enrichment_columns = c(spec[["system_column"]], spec[["code_column"]])
+  enrichment_columns = c(spec[["system_column"]], spec[["code_column"]]),
+  ingredient_reference_column =
+    SNAPSHOT_MEDICATION_INGREDIENT_REFERENCE_COLUMN
 ) {
   source_alias <- "snapshot_source"
   medication_alias <- "medication_codes"
@@ -62,11 +64,138 @@ buildSnapshotMedicationSourceQuery <- function(
   quoted_med_id <- snapshotQuotedColumn(connection, "med_id")
   quoted_med_system <- snapshotQuotedColumn(connection, "med_code_system")
   quoted_med_code <- snapshotQuotedColumn(connection, "med_code_code")
+  quoted_issue_target <- snapshotQuotedColumn(
+    connection,
+    SNAPSHOT_MEDICATION_REFERENCE_ISSUES_COLUMN
+  )
   normalized_reference <- paste0(
     "regexp_replace(regexp_replace(", quoted_reference,
     "::text, '^\\[[^]]+\\]', ''), '^Medication/', '')"
   )
-
+  medication_nodes_query <- paste0(
+    "SELECT DISTINCT ", quoted_med_id, "::text AS medication_id\n",
+    "FROM ", medication_relation, "\n",
+    "WHERE NULLIF(", quoted_med_id, "::text, '') IS NOT NULL"
+  )
+  medication_edges_query <- if (is.null(ingredient_reference_column)) {
+    paste(
+      "SELECT NULL::text AS source_medication_id,",
+      "NULL::text AS target_medication_id",
+      "WHERE FALSE"
+    )
+  } else {
+    quoted_ingredient_reference <- snapshotQuotedColumn(
+      connection,
+      ingredient_reference_column
+    )
+    normalized_ingredient_reference <- paste0(
+      "regexp_replace(regexp_replace(", quoted_ingredient_reference,
+      "::text, '^\\[[^]]+\\]', ''), '^Medication/', '')"
+    )
+    paste0(
+      "SELECT DISTINCT ", quoted_med_id,
+      "::text AS source_medication_id,\n",
+      normalized_ingredient_reference, " AS target_medication_id\n",
+      "FROM ", medication_relation, "\n",
+      "WHERE NULLIF(", quoted_med_id, "::text, '') IS NOT NULL\n",
+      "AND NULLIF(", normalized_ingredient_reference, ", '') IS NOT NULL"
+    )
+  }
+  source_roots_query <- paste0(
+    "SELECT DISTINCT ", normalized_reference, " AS root_medication_id\n",
+    "FROM ", source_relation, " ", source_alias, "\n",
+    "WHERE NULLIF(", normalized_reference, ", '') IS NOT NULL"
+  )
+  medication_walk_query <- paste(
+    "SELECT root_medication_id, root_medication_id",
+    "FROM source_roots",
+    # UNION deduplicates every root/node pair, so cycles terminate naturally.
+    "UNION",
+    "SELECT medication_walk.root_medication_id,",
+    "medication_edges.target_medication_id",
+    "FROM medication_walk",
+    "JOIN medication_edges",
+    "ON medication_edges.source_medication_id = medication_walk.medication_id",
+    sep = "\n"
+  )
+  medication_code_values_query <- paste0(
+    "SELECT DISTINCT medication_walk.root_medication_id,\n",
+    "medication.", quoted_med_system, " AS medication_system,\n",
+    "medication.", quoted_med_code, " AS medication_code\n",
+    "FROM medication_walk\n",
+    "JOIN ", medication_relation, " medication\n",
+    "ON medication.", quoted_med_id,
+    "::text = medication_walk.medication_id\n",
+    "WHERE NULLIF(medication.", quoted_med_system,
+    "::text, '') IS NOT NULL\n",
+    "AND NULLIF(medication.", quoted_med_code, "::text, '') IS NOT NULL"
+  )
+  medication_codes_query <- paste(
+    "SELECT root_medication_id, medication_system, medication_code,",
+    "row_number() OVER (",
+    "  PARTITION BY root_medication_id",
+    "  ORDER BY medication_system, medication_code",
+    ") AS code_number",
+    "FROM medication_code_values",
+    sep = "\n"
+  )
+  medication_issues_query <- paste(
+    "SELECT DISTINCT medication_walk.root_medication_id,",
+    "'missing_medication'::text AS issue_type,",
+    "medication_walk.medication_id AS related_medication_id",
+    "FROM medication_walk",
+    "LEFT JOIN medication_nodes",
+    "ON medication_nodes.medication_id = medication_walk.medication_id",
+    "WHERE medication_nodes.medication_id IS NULL",
+    "UNION",
+    "SELECT source_roots.root_medication_id,",
+    "'no_reachable_code'::text AS issue_type,",
+    "source_roots.root_medication_id AS related_medication_id",
+    "FROM source_roots",
+    "JOIN medication_nodes",
+    "ON medication_nodes.medication_id = source_roots.root_medication_id",
+    "WHERE NOT EXISTS (",
+    "  SELECT 1",
+    "  FROM medication_code_values",
+    paste0(
+      "  WHERE medication_code_values.root_medication_id = ",
+      "source_roots.root_medication_id"
+    ),
+    ")",
+    sep = "\n"
+  )
+  medication_issue_summary_query <- paste(
+    "SELECT root_medication_id,",
+    "string_agg(",
+    "  issue_type || E'\\t' || related_medication_id,",
+    "  E'\\n' ORDER BY issue_type, related_medication_id",
+    ") AS issues",
+    "FROM medication_issues",
+    "GROUP BY root_medication_id",
+    sep = "\n"
+  )
+  ctes <- c(
+    paste0("medication_nodes AS (\n", medication_nodes_query, "\n)"),
+    paste0("medication_edges AS (\n", medication_edges_query, "\n)"),
+    paste0("source_roots AS (\n", source_roots_query, "\n)"),
+    paste0(
+      "medication_walk(root_medication_id, medication_id) AS (\n",
+      medication_walk_query,
+      "\n)"
+    ),
+    paste0(
+      "medication_code_values AS (\n",
+      medication_code_values_query,
+      "\n)"
+    ),
+    paste0(medication_alias, " AS (\n", medication_codes_query, "\n)"),
+    paste0("medication_issues AS (\n", medication_issues_query, "\n)"),
+    paste0(
+      "medication_issue_summary AS (\n",
+      medication_issue_summary_query,
+      "\n)"
+    )
+  )
   enrichment_select <- c(
     if (system_column %in% enrichment_columns) {
       paste0(
@@ -81,19 +210,27 @@ buildSnapshotMedicationSourceQuery <- function(
       )
     }
   )
+  issue_select <- paste0(
+    # Issues are attached once per source row, not once per resolved code.
+    "CASE WHEN COALESCE(", medication_alias, ".code_number, 1) = 1 ",
+    "THEN medication_issue_summary.issues ELSE NULL END AS ",
+    quoted_issue_target
+  )
+  select_query <- paste0(
+    "SELECT ",
+    paste(c(source_columns, enrichment_select, issue_select), collapse = ",\n"),
+    "\nFROM ", source_relation, " ", source_alias, "\n",
+    "LEFT JOIN ", medication_alias, "\n",
+    "ON ", medication_alias, ".root_medication_id = ", normalized_reference,
+    "\nLEFT JOIN medication_issue_summary\n",
+    "ON medication_issue_summary.root_medication_id = ", normalized_reference
+  )
 
   paste0(
-    "WITH ", medication_alias, " AS (",
-    "SELECT DISTINCT ", quoted_med_id, "::text AS medication_id, ",
-    quoted_med_system, " AS medication_system, ",
-    quoted_med_code, " AS medication_code FROM ", medication_relation, " ",
-    "WHERE NULLIF(", quoted_med_id, "::text, '') IS NOT NULL ",
-    "AND NULLIF(", quoted_med_system, "::text, '') IS NOT NULL ",
-    "AND NULLIF(", quoted_med_code, "::text, '') IS NOT NULL)",
-    " SELECT ", source_columns, ", ", paste(enrichment_select, collapse = ", "),
-    " FROM ", source_relation, " ", source_alias,
-    " LEFT JOIN ", medication_alias,
-    " ON ", medication_alias, ".medication_id = ", normalized_reference
+    "WITH RECURSIVE\n",
+    paste(ctes, collapse = ",\n"),
+    "\n",
+    select_query
   )
 }
 
@@ -194,7 +331,11 @@ getSnapshotStreamingSourceQuery <- function(
       dependency_suffix
     )
     required_source_fields <- medication_spec[["reference_column"]]
-    required_medication_fields <- c("med_id", "med_code_system", "med_code_code")
+    required_medication_fields <- c(
+      "med_id",
+      "med_code_system",
+      "med_code_code"
+    )
     if (
       required_source_fields %in% described_columns &&
       required_source_fields %in% source_fields &&
@@ -217,7 +358,15 @@ getSnapshotStreamingSourceQuery <- function(
               source_schema
             ),
             medication_spec,
-            medication_enrichment_columns
+            medication_enrichment_columns,
+            ingredient_reference_column = if (
+              SNAPSHOT_MEDICATION_INGREDIENT_REFERENCE_COLUMN %in%
+                medication_fields
+            ) {
+              SNAPSHOT_MEDICATION_INGREDIENT_REFERENCE_COLUMN
+            } else {
+              NULL
+            }
           ),
           medication_spec = medication_spec
         ))
@@ -416,7 +565,8 @@ processSnapshotChunkStream <- function(
   review_chunk,
   write_review_chunk,
   chunk_size,
-  table_name
+  table_name,
+  strip_review_columns = identity
 ) {
   first_chunk <- TRUE
   chunk_number <- 0L
@@ -426,6 +576,7 @@ processSnapshotChunkStream <- function(
     chunk_number <- chunk_number + 1L
     chunk <- enrich_chunk(data.table::as.data.table(chunk))
     write_review_chunk(review_chunk(chunk))
+    chunk <- strip_review_columns(chunk)
     table_result <- pseudonymize_chunk(chunk, chunk_number)
     output <- table_result[["table"]]
     write_chunk(output, first_chunk)
@@ -452,6 +603,20 @@ processSnapshotChunkStream <- function(
     summary = summary,
     chunks = chunk_number
   )
+}
+
+stripSnapshotStreamingReviewColumns <- function(table) {
+  table <- data.table::as.data.table(table)
+  review_columns <- intersect(
+    SNAPSHOT_MEDICATION_REFERENCE_ISSUES_COLUMN,
+    names(table)
+  )
+  if (length(review_columns) > 0) {
+    for (review_column in review_columns) {
+      table[[review_column]] <- NULL
+    }
+  }
+  table
 }
 
 streamSnapshotMaterializedTable <- function(

--- a/R-cdstoolchain/pseudonym/R/pseudonymize_snapshot_streaming.R
+++ b/R-cdstoolchain/pseudonym/R/pseudonymize_snapshot_streaming.R
@@ -39,39 +39,29 @@ snapshotDependencySuffix <- function(plan_row, last_version_suffix) {
   ""
 }
 
-buildSnapshotMedicationSourceQuery <- function(
+snapshotNormalizedReferenceExpression <- function(
   connection,
-  source_relation,
-  source_fields,
+  column_name,
+  alias = NULL,
+  resource_type = "Medication"
+) {
+  quoted_reference <- snapshotQuotedColumn(connection, column_name, alias)
+  paste0(
+    "NULLIF(regexp_replace(regexp_replace(", quoted_reference,
+    "::text, '^\\[[^]]+\\]', ''), '^", resource_type, "/', ''), '')"
+  )
+}
+
+buildSnapshotMedicationResolutionQuery <- function(
+  connection,
+  source_root_queries,
   medication_relation,
-  spec,
-  enrichment_columns = c(spec[["system_column"]], spec[["code_column"]]),
   ingredient_reference_column =
     SNAPSHOT_MEDICATION_INGREDIENT_REFERENCE_COLUMN
 ) {
-  source_alias <- "snapshot_source"
-  medication_alias <- "medication_codes"
-  reference_column <- spec[["reference_column"]]
-  system_column <- spec[["system_column"]]
-  code_column <- spec[["code_column"]]
-  source_columns <- snapshotSelectColumns(
-    connection,
-    source_fields,
-    source_alias,
-    exclude = c(system_column, code_column)
-  )
-  quoted_reference <- snapshotQuotedColumn(connection, reference_column, source_alias)
   quoted_med_id <- snapshotQuotedColumn(connection, "med_id")
   quoted_med_system <- snapshotQuotedColumn(connection, "med_code_system")
   quoted_med_code <- snapshotQuotedColumn(connection, "med_code_code")
-  quoted_issue_target <- snapshotQuotedColumn(
-    connection,
-    SNAPSHOT_MEDICATION_REFERENCE_ISSUES_COLUMN
-  )
-  normalized_reference <- paste0(
-    "regexp_replace(regexp_replace(", quoted_reference,
-    "::text, '^\\[[^]]+\\]', ''), '^Medication/', '')"
-  )
   medication_nodes_query <- paste0(
     "SELECT DISTINCT ", quoted_med_id, "::text AS medication_id\n",
     "FROM ", medication_relation, "\n",
@@ -84,13 +74,9 @@ buildSnapshotMedicationSourceQuery <- function(
       "WHERE FALSE"
     )
   } else {
-    quoted_ingredient_reference <- snapshotQuotedColumn(
+    normalized_ingredient_reference <- snapshotNormalizedReferenceExpression(
       connection,
       ingredient_reference_column
-    )
-    normalized_ingredient_reference <- paste0(
-      "regexp_replace(regexp_replace(", quoted_ingredient_reference,
-      "::text, '^\\[[^]]+\\]', ''), '^Medication/', '')"
     )
     paste0(
       "SELECT DISTINCT ", quoted_med_id,
@@ -98,13 +84,16 @@ buildSnapshotMedicationSourceQuery <- function(
       normalized_ingredient_reference, " AS target_medication_id\n",
       "FROM ", medication_relation, "\n",
       "WHERE NULLIF(", quoted_med_id, "::text, '') IS NOT NULL\n",
-      "AND NULLIF(", normalized_ingredient_reference, ", '') IS NOT NULL"
+      "AND ", normalized_ingredient_reference, " IS NOT NULL"
     )
   }
-  source_roots_query <- paste0(
-    "SELECT DISTINCT ", normalized_reference, " AS root_medication_id\n",
-    "FROM ", source_relation, " ", source_alias, "\n",
-    "WHERE NULLIF(", normalized_reference, ", '') IS NOT NULL"
+  source_roots_query <- paste(
+    "SELECT DISTINCT root_medication_id",
+    "FROM (",
+    paste(source_root_queries, collapse = "\nUNION ALL\n"),
+    ") medication_root_candidates",
+    "WHERE root_medication_id IS NOT NULL",
+    sep = "\n"
   )
   medication_walk_query <- paste(
     "SELECT root_medication_id, root_medication_id",
@@ -188,7 +177,7 @@ buildSnapshotMedicationSourceQuery <- function(
       medication_code_values_query,
       "\n)"
     ),
-    paste0(medication_alias, " AS (\n", medication_codes_query, "\n)"),
+    paste0("medication_codes AS (\n", medication_codes_query, "\n)"),
     paste0("medication_issues AS (\n", medication_issues_query, "\n)"),
     paste0(
       "medication_issue_summary AS (\n",
@@ -196,41 +185,72 @@ buildSnapshotMedicationSourceQuery <- function(
       "\n)"
     )
   )
+  paste0(
+    "WITH RECURSIVE\n",
+    paste(ctes, collapse = ",\n"),
+    "\nSELECT source_roots.root_medication_id,\n",
+    "medication_codes.medication_system,\n",
+    "medication_codes.medication_code,\n",
+    # Issues are stored once per root, not once per resolved code.
+    "CASE WHEN COALESCE(medication_codes.code_number, 1) = 1 ",
+    "THEN medication_issue_summary.issues ELSE NULL END AS issues\n",
+    "FROM source_roots\n",
+    "LEFT JOIN medication_codes\n",
+    "ON medication_codes.root_medication_id = source_roots.root_medication_id\n",
+    "LEFT JOIN medication_issue_summary\n",
+    "ON medication_issue_summary.root_medication_id = source_roots.root_medication_id"
+  )
+}
+
+buildSnapshotMedicationSourceQuery <- function(
+  connection,
+  source_relation,
+  source_fields,
+  medication_resolution_relation,
+  spec,
+  enrichment_columns = c(spec[["system_column"]], spec[["code_column"]])
+) {
+  source_alias <- "snapshot_source"
+  resolution_alias <- "medication_resolution"
+  reference_column <- spec[["reference_column"]]
+  system_column <- spec[["system_column"]]
+  code_column <- spec[["code_column"]]
+  source_columns <- snapshotSelectColumns(
+    connection,
+    source_fields,
+    source_alias,
+    exclude = c(system_column, code_column)
+  )
+  normalized_reference <- snapshotNormalizedReferenceExpression(
+    connection,
+    reference_column,
+    source_alias
+  )
   enrichment_select <- c(
     if (system_column %in% enrichment_columns) {
       paste0(
-        medication_alias, ".medication_system AS ",
+        resolution_alias, ".medication_system AS ",
         snapshotQuotedColumn(connection, system_column)
       )
     },
     if (code_column %in% enrichment_columns) {
       paste0(
-        medication_alias, ".medication_code AS ",
+        resolution_alias, ".medication_code AS ",
         snapshotQuotedColumn(connection, code_column)
       )
     }
   )
   issue_select <- paste0(
-    # Issues are attached once per source row, not once per resolved code.
-    "CASE WHEN COALESCE(", medication_alias, ".code_number, 1) = 1 ",
-    "THEN medication_issue_summary.issues ELSE NULL END AS ",
-    quoted_issue_target
-  )
-  select_query <- paste0(
-    "SELECT ",
-    paste(c(source_columns, enrichment_select, issue_select), collapse = ",\n"),
-    "\nFROM ", source_relation, " ", source_alias, "\n",
-    "LEFT JOIN ", medication_alias, "\n",
-    "ON ", medication_alias, ".root_medication_id = ", normalized_reference,
-    "\nLEFT JOIN medication_issue_summary\n",
-    "ON medication_issue_summary.root_medication_id = ", normalized_reference
+    resolution_alias, ".issues AS ",
+    snapshotQuotedColumn(connection, SNAPSHOT_MEDICATION_REFERENCE_ISSUES_COLUMN)
   )
 
   paste0(
-    "WITH RECURSIVE\n",
-    paste(ctes, collapse = ",\n"),
-    "\n",
-    select_query
+    "SELECT ",
+    paste(c(source_columns, enrichment_select, issue_select), collapse = ",\n"),
+    "\nFROM ", source_relation, " ", source_alias, "\n",
+    "LEFT JOIN ", medication_resolution_relation, " ", resolution_alias, "\n",
+    "ON ", resolution_alias, ".root_medication_id = ", normalized_reference
   )
 }
 
@@ -294,13 +314,184 @@ buildSnapshotBirthdateMapQuery <- function(
   )
 }
 
+getSnapshotMedicationRootQueries <- function(
+  connection,
+  materialization_plan,
+  rules,
+  relation_type,
+  source_schema
+) {
+  plan_rows <- which(materialization_plan[["SNAPSHOT_RELATION_TYPE"]] == relation_type)
+  root_queries <- list()
+  for (row_index in plan_rows) {
+    plan_row <- materialization_plan[row_index, ]
+    medication_spec <- getMedicationReferenceSpec(plan_row[["BASE_TABLE_NAME"]])
+    if (is.null(medication_spec)) {
+      next
+    }
+
+    table_rules <- getPseudonymizationRulesForTable(
+      rules,
+      plan_row[["RULE_TABLE_NAME"]],
+      source = plan_row[["RULE_SOURCE"]]
+    )
+    described_columns <- unique(table_rules[["COLUMN_NAME"]])
+    enrichment_columns <- intersect(
+      c(
+        medication_spec[["system_column"]],
+        medication_spec[["code_column"]]
+      ),
+      described_columns
+    )
+    reference_column <- medication_spec[["reference_column"]]
+    source_relation_name <- plan_row[["SOURCE_RELATION"]]
+    source_fields <- snapshotRelationFields(
+      connection,
+      source_relation_name,
+      source_schema
+    )
+    if (
+      length(enrichment_columns) == 0 ||
+      !reference_column %in% described_columns ||
+      !reference_column %in% source_fields
+    ) {
+      next
+    }
+
+    normalized_reference <- snapshotNormalizedReferenceExpression(
+      connection,
+      reference_column,
+      alias = "snapshot_source"
+    )
+    source_relation <- snapshotQualifiedName(
+      connection,
+      source_relation_name,
+      source_schema
+    )
+    root_queries[[length(root_queries) + 1L]] <- paste0(
+      "SELECT DISTINCT ", normalized_reference,
+      " AS root_medication_id\n",
+      "FROM ", source_relation, " snapshot_source\n",
+      "WHERE ", normalized_reference, " IS NOT NULL"
+    )
+  }
+  unname(unlist(root_queries, use.names = FALSE))
+}
+
+prepareSnapshotMedicationResolutionTables <- function(
+  connection,
+  materialization_plan,
+  rules,
+  source_schema,
+  source_view_prefix,
+  last_version_suffix
+) {
+  resolution_tables <- list()
+  relation_types <- unique(materialization_plan[["SNAPSHOT_RELATION_TYPE"]])
+  for (relation_type in relation_types) {
+    source_root_queries <- getSnapshotMedicationRootQueries(
+      connection,
+      materialization_plan,
+      rules,
+      relation_type,
+      source_schema
+    )
+    if (length(source_root_queries) == 0) {
+      next
+    }
+
+    medication_suffix <- if (identical(relation_type, "last_version")) {
+      last_version_suffix
+    } else {
+      ""
+    }
+    medication_relation_name <- paste0(
+      source_view_prefix,
+      "medication",
+      medication_suffix
+    )
+    if (!snapshotRelationExists(
+      connection,
+      medication_relation_name,
+      source_schema
+    )) {
+      next
+    }
+    medication_fields <- snapshotRelationFields(
+      connection,
+      medication_relation_name,
+      source_schema
+    )
+    required_medication_fields <- c(
+      "med_id",
+      "med_code_system",
+      "med_code_code"
+    )
+    if (!all(required_medication_fields %in% medication_fields)) {
+      next
+    }
+
+    medication_relation <- snapshotQualifiedName(
+      connection,
+      medication_relation_name,
+      source_schema
+    )
+    resolution_query <- buildSnapshotMedicationResolutionQuery(
+      connection,
+      source_root_queries,
+      medication_relation,
+      ingredient_reference_column = if (
+        SNAPSHOT_MEDICATION_INGREDIENT_REFERENCE_COLUMN %in%
+          medication_fields
+      ) {
+        SNAPSHOT_MEDICATION_INGREDIENT_REFERENCE_COLUMN
+      } else {
+        NULL
+      }
+    )
+    resolution_table_name <- basename(tempfile(
+      pattern = paste0("snapshot_medication_resolution_", relation_type, "_")
+    ))
+    resolution_table <- snapshotQualifiedName(
+      connection,
+      resolution_table_name
+    )
+    created_rows <- DBI::dbExecute(
+      connection,
+      paste0("CREATE TEMP TABLE ", resolution_table, " AS\n", resolution_query)
+    )
+    DBI::dbExecute(
+      connection,
+      paste0("CREATE INDEX ON ", resolution_table, " (root_medication_id)")
+    )
+    DBI::dbExecute(connection, paste0("ANALYZE ", resolution_table))
+    message(
+      "Prepared shared Medication resolution for ", relation_type,
+      ": ", created_rows, " root/code rows"
+    )
+    resolution_tables[[relation_type]] <- resolution_table_name
+  }
+  resolution_tables
+}
+
+dropSnapshotMedicationResolutionTables <- function(connection, tables) {
+  for (table_name in unname(unlist(tables, use.names = FALSE))) {
+    DBI::dbExecute(
+      connection,
+      paste0("DROP TABLE IF EXISTS ", snapshotQualifiedName(connection, table_name))
+    )
+  }
+  invisible()
+}
+
 getSnapshotStreamingSourceQuery <- function(
   connection,
   plan_row,
   source_schema,
   source_view_prefix,
   last_version_suffix,
-  described_columns
+  described_columns,
+  medication_resolution_tables = list()
 ) {
   source_relation_name <- plan_row[["SOURCE_RELATION"]]
   source_relation <- snapshotQualifiedName(
@@ -325,52 +516,25 @@ getSnapshotStreamingSourceQuery <- function(
     character()
   }
   if (!is.null(medication_spec) && length(medication_enrichment_columns) > 0) {
-    medication_relation_name <- paste0(
-      source_view_prefix,
-      "medication",
-      dependency_suffix
-    )
-    required_source_fields <- medication_spec[["reference_column"]]
-    required_medication_fields <- c(
-      "med_id",
-      "med_code_system",
-      "med_code_code"
-    )
+    reference_column <- medication_spec[["reference_column"]]
+    relation_type <- plan_row[["SNAPSHOT_RELATION_TYPE"]]
+    resolution_table_name <- medication_resolution_tables[[relation_type]]
     if (
-      required_source_fields %in% described_columns &&
-      required_source_fields %in% source_fields &&
-      snapshotRelationExists(connection, medication_relation_name, source_schema)
+      reference_column %in% described_columns &&
+      reference_column %in% source_fields &&
+      !is.null(resolution_table_name)
     ) {
-      medication_fields <- snapshotRelationFields(
-        connection,
-        medication_relation_name,
-        source_schema
-      )
-      if (all(required_medication_fields %in% medication_fields)) {
-        return(list(
-          query = buildSnapshotMedicationSourceQuery(
-            connection,
-            source_relation,
-            source_fields,
-            snapshotQualifiedName(
-              connection,
-              medication_relation_name,
-              source_schema
-            ),
-            medication_spec,
-            medication_enrichment_columns,
-            ingredient_reference_column = if (
-              SNAPSHOT_MEDICATION_INGREDIENT_REFERENCE_COLUMN %in%
-                medication_fields
-            ) {
-              SNAPSHOT_MEDICATION_INGREDIENT_REFERENCE_COLUMN
-            } else {
-              NULL
-            }
-          ),
-          medication_spec = medication_spec
-        ))
-      }
+      return(list(
+        query = buildSnapshotMedicationSourceQuery(
+          connection,
+          source_relation,
+          source_fields,
+          snapshotQualifiedName(connection, resolution_table_name),
+          medication_spec,
+          medication_enrichment_columns
+        ),
+        medication_spec = medication_spec
+      ))
     }
   }
 
@@ -463,9 +627,13 @@ getSnapshotStreamingSourceQuery <- function(
   )
 }
 
-newSnapshotStreamingContext <- function(input_repo_path) {
+newSnapshotStreamingContext <- function(
+  input_repo_path,
+  medication_resolution_tables = list()
+) {
   context <- new.env(parent = emptyenv())
   context$input_repo_path <- input_repo_path
+  context$medication_resolution_tables <- medication_resolution_tables
   context$loinc_mapping <- NULL
   context$mapping_context <- newPseudonymMappingContext(input_repo_path)
   context$medication_review <- newBoundedMedicationReferenceReview(
@@ -665,7 +833,9 @@ streamSnapshotMaterializedTable <- function(
     source_schema,
     source_view_prefix,
     last_version_suffix,
-    described_columns
+    described_columns,
+    medication_resolution_tables =
+      streaming_context$medication_resolution_tables
   )
   message(
     "Streaming snapshot source relation ",

--- a/R-cdstoolchain/pseudonym/tests/testthat/test-pseudonymize-snapshot-streaming.R
+++ b/R-cdstoolchain/pseudonym/tests/testthat/test-pseudonymize-snapshot-streaming.R
@@ -92,37 +92,49 @@ test_that("processSnapshotChunkStream writes an empty relation once", {
   expect_equal(result$summary$OUTPUT_ROWS, 0L)
 })
 
-test_that("medication source query resolves codes in the source database", {
-  spec <- getMedicationReferenceSpec("medicationrequest")
-  query <- buildSnapshotMedicationSourceQuery(
+test_that("shared medication resolution query traverses the reference graph", {
+  root_queries <- c(
+    "SELECT 'med-1'::text AS root_medication_id",
+    "SELECT 'med-2'::text AS root_medication_id"
+  )
+  query <- buildSnapshotMedicationResolutionQuery(
     DBI::ANSI(),
-    '"db2dataprocessor_out"."v_medicationrequest"',
-    c("medreq_id", "medreq_medicationreference_ref"),
-    '"db2dataprocessor_out"."v_medication"',
-    spec
+    root_queries,
+    '"db2dataprocessor_out"."v_medication"'
   )
 
   expect_match(query, "WITH RECURSIVE\nmedication_nodes AS", fixed = TRUE)
+  expect_match(query, "UNION ALL", fixed = TRUE)
   expect_match(query, "medication_edges AS", fixed = TRUE)
   expect_match(query, "medication_walk(root_medication_id, medication_id)", fixed = TRUE)
   expect_match(query, "FROM medication_walk\nJOIN medication_edges", fixed = TRUE)
-  expect_match(query, "^Medication/", fixed = TRUE)
-  expect_match(query, "AS \"medreq_medication_system\"", fixed = TRUE)
-  expect_match(query, "AS \"medreq_medication_code\"", fixed = TRUE)
-  expect_match(query, "LEFT JOIN medication_codes", fixed = TRUE)
   expect_match(query, "missing_medication", fixed = TRUE)
   expect_match(query, "no_reachable_code", fixed = TRUE)
-  expect_match(query, SNAPSHOT_MEDICATION_REFERENCE_ISSUES_COLUMN, fixed = TRUE)
 })
 
-test_that("medication source query keeps direct codes without ingredient references", {
+test_that("medication source query joins the prepared shared resolution", {
   spec <- getMedicationReferenceSpec("medicationrequest")
   query <- buildSnapshotMedicationSourceQuery(
     DBI::ANSI(),
     '"db2dataprocessor_out"."v_medicationrequest"',
     c("medreq_id", "medreq_medicationreference_ref"),
+    '"snapshot_medication_resolution_all"',
+    spec
+  )
+
+  expect_false(grepl("WITH RECURSIVE", query, fixed = TRUE))
+  expect_match(query, "^Medication/", fixed = TRUE)
+  expect_match(query, "AS \"medreq_medication_system\"", fixed = TRUE)
+  expect_match(query, "AS \"medreq_medication_code\"", fixed = TRUE)
+  expect_match(query, "LEFT JOIN \"snapshot_medication_resolution_all\"", fixed = TRUE)
+  expect_match(query, SNAPSHOT_MEDICATION_REFERENCE_ISSUES_COLUMN, fixed = TRUE)
+})
+
+test_that("shared medication resolution keeps direct codes without ingredient references", {
+  query <- buildSnapshotMedicationResolutionQuery(
+    DBI::ANSI(),
+    "SELECT 'med-1'::text AS root_medication_id",
     '"db2dataprocessor_out"."v_medication"',
-    spec,
     ingredient_reference_column = NULL
   )
 
@@ -138,7 +150,7 @@ test_that("medication source query supports every configured reference table", {
       DBI::ANSI(),
       '"db2dataprocessor_out"."v_source"',
       c("source_id", spec[["reference_column"]]),
-      '"db2dataprocessor_out"."v_medication"',
+      '"snapshot_medication_resolution_all"',
       spec
     )
 
@@ -153,6 +165,65 @@ test_that("medication source query supports every configured reference table", {
       fixed = TRUE
     )
   }
+})
+
+test_that("shared medication resolution combines roots from all source resources", {
+  plan <- data.table::data.table(
+    BASE_TABLE_NAME = c(
+      "medicationrequest",
+      "medicationstatement",
+      "medicationadministration"
+    ),
+    RULE_TABLE_NAME = c(
+      "medicationrequest",
+      "medicationstatement",
+      "medicationadministration"
+    ),
+    RULE_SOURCE = NA_character_,
+    SOURCE_RELATION = c(
+      "v_medicationrequest",
+      "v_medicationstatement",
+      "v_medicationadministration"
+    ),
+    SNAPSHOT_RELATION_TYPE = "all"
+  )
+  rules <- data.table::rbindlist(lapply(
+    seq_len(nrow(SNAPSHOT_MEDICATION_REFERENCE_SPECS)),
+    function(row_index) {
+      spec <- SNAPSHOT_MEDICATION_REFERENCE_SPECS[row_index, ]
+      data.table::data.table(
+        TABLE_OR_RESOURCE = spec[["table_name"]],
+        SOURCE = NA_character_,
+        COLUMN_NAME = c(
+          spec[["reference_column"]],
+          spec[["system_column"]],
+          spec[["code_column"]]
+        ),
+        PSEUDONYMIZATION_RULE = "keep"
+      )
+    }
+  ))
+  testthat::local_mocked_bindings(
+    snapshotRelationFields = function(connection, name, schema = NULL) {
+      spec <- getMedicationReferenceSpec(sub("^v_", "", name))
+      c("row_id", spec[["reference_column"]])
+    }
+  )
+
+  queries <- getSnapshotMedicationRootQueries(
+    DBI::ANSI(),
+    plan,
+    rules,
+    relation_type = "all",
+    source_schema = NULL
+  )
+
+  expect_length(queries, 3L)
+  expect_true(all(vapply(
+    plan$SOURCE_RELATION,
+    function(relation_name) any(grepl(relation_name, queries, fixed = TRUE)),
+    logical(1)
+  )))
 })
 
 test_that("birthdate source query supports fallback patient keys", {

--- a/R-cdstoolchain/pseudonym/tests/testthat/test-pseudonymize-snapshot-streaming.R
+++ b/R-cdstoolchain/pseudonym/tests/testthat/test-pseudonymize-snapshot-streaming.R
@@ -102,12 +102,57 @@ test_that("medication source query resolves codes in the source database", {
     spec
   )
 
-  expect_match(query, "WITH medication_codes AS", fixed = TRUE)
-  expect_match(query, "SELECT DISTINCT \"med_id\"::text", fixed = TRUE)
+  expect_match(query, "WITH RECURSIVE\nmedication_nodes AS", fixed = TRUE)
+  expect_match(query, "medication_edges AS", fixed = TRUE)
+  expect_match(query, "medication_walk(root_medication_id, medication_id)", fixed = TRUE)
+  expect_match(query, "FROM medication_walk\nJOIN medication_edges", fixed = TRUE)
   expect_match(query, "^Medication/", fixed = TRUE)
   expect_match(query, "AS \"medreq_medication_system\"", fixed = TRUE)
   expect_match(query, "AS \"medreq_medication_code\"", fixed = TRUE)
   expect_match(query, "LEFT JOIN medication_codes", fixed = TRUE)
+  expect_match(query, "missing_medication", fixed = TRUE)
+  expect_match(query, "no_reachable_code", fixed = TRUE)
+  expect_match(query, SNAPSHOT_MEDICATION_REFERENCE_ISSUES_COLUMN, fixed = TRUE)
+})
+
+test_that("medication source query keeps direct codes without ingredient references", {
+  spec <- getMedicationReferenceSpec("medicationrequest")
+  query <- buildSnapshotMedicationSourceQuery(
+    DBI::ANSI(),
+    '"db2dataprocessor_out"."v_medicationrequest"',
+    c("medreq_id", "medreq_medicationreference_ref"),
+    '"db2dataprocessor_out"."v_medication"',
+    spec,
+    ingredient_reference_column = NULL
+  )
+
+  expect_match(query, "medication_edges AS", fixed = TRUE)
+  expect_match(query, "WHERE FALSE", fixed = TRUE)
+  expect_match(query, "medication_code_values AS", fixed = TRUE)
+})
+
+test_that("medication source query supports every configured reference table", {
+  for (i in seq_len(nrow(SNAPSHOT_MEDICATION_REFERENCE_SPECS))) {
+    spec <- SNAPSHOT_MEDICATION_REFERENCE_SPECS[i, ]
+    query <- buildSnapshotMedicationSourceQuery(
+      DBI::ANSI(),
+      '"db2dataprocessor_out"."v_source"',
+      c("source_id", spec[["reference_column"]]),
+      '"db2dataprocessor_out"."v_medication"',
+      spec
+    )
+
+    expect_match(
+      query,
+      paste0('AS "', spec[["system_column"]], '"'),
+      fixed = TRUE
+    )
+    expect_match(
+      query,
+      paste0('AS "', spec[["code_column"]], '"'),
+      fixed = TRUE
+    )
+  }
 })
 
 test_that("birthdate source query supports fallback patient keys", {
@@ -358,8 +403,90 @@ test_that("streaming medication review keeps exact counts and bounded examples",
   result <- finalizeBoundedMedicationReferenceReview(context)
 
   expect_equal(result$summary$UNMATCHED_ROWS, 2)
+  expect_equal(result$summary$ISSUE_TYPE, "no_reachable_code")
   expect_equal(nrow(result$unmatched_reference_examples), 1L)
   expect_equal(result$unmatched_reference_examples$MEDICATION_ID, "missing")
+})
+
+test_that("streaming medication review expands multiple graph issues once", {
+  spec <- getMedicationReferenceSpec("medicationrequest")
+  chunk <- data.table::data.table(
+    medreq_medicationreference_ref = c(
+      "Medication/mixture",
+      "Medication/mixture"
+    ),
+    medreq_medication_system = c("http://atc", "http://snomed"),
+    medreq_medication_code = c("A01", "C01")
+  )
+  chunk[[SNAPSHOT_MEDICATION_REFERENCE_ISSUES_COLUMN]] <- c(
+    paste(
+      "missing_medication\tmissing-a",
+      "missing_medication\tmissing-b",
+      sep = "\n"
+    ),
+    NA_character_
+  )
+
+  report <- getUnmatchedMedicationReferencesFromEnrichedTable(
+    chunk,
+    "medicationrequest",
+    spec
+  )
+
+  expect_equal(nrow(report), 2L)
+  expect_equal(report$RELATED_MEDICATION_ID, c("missing-a", "missing-b"))
+  expect_equal(report$N, c(1L, 1L))
+})
+
+test_that("streaming review columns are removed before pseudonymization", {
+  fetched <- FALSE
+  captured <- new.env(parent = emptyenv())
+  captured$reviewed_issue <- NULL
+  pseudonymized_names <- NULL
+  written_names <- NULL
+  chunk <- data.table::data.table(value = 1L)
+  chunk[[SNAPSHOT_MEDICATION_REFERENCE_ISSUES_COLUMN]] <-
+    "missing_medication\tmissing"
+
+  processSnapshotChunkStream(
+    fetch_chunk = function(chunk_size) {
+      fetched <<- TRUE
+      chunk
+    },
+    has_completed = function() fetched,
+    enrich_chunk = identity,
+    pseudonymize_chunk = function(chunk, chunk_number) {
+      pseudonymized_names <<- names(chunk)
+      list(
+        table = chunk,
+        summary = data.table::data.table(
+          INPUT_ROWS = nrow(chunk),
+          OUTPUT_ROWS = nrow(chunk),
+          OUTPUT_COLUMNS = ncol(chunk)
+        )
+      )
+    },
+    write_chunk = function(output, first_chunk) {
+      written_names <<- names(output)
+    },
+    review_chunk = function(chunk) {
+      captured$reviewed_issue <- paste(
+        chunk[[SNAPSHOT_MEDICATION_REFERENCE_ISSUES_COLUMN]],
+        collapse = "\n"
+      )
+      emptyMedicationReferenceReport()
+    },
+    write_review_chunk = function(review) {
+      force(review)
+    },
+    chunk_size = 1L,
+    table_name = "example",
+    strip_review_columns = stripSnapshotStreamingReviewColumns
+  )
+
+  expect_equal(captured$reviewed_issue, "missing_medication\tmissing")
+  expect_equal(pseudonymized_names, "value")
+  expect_equal(written_names, "value")
 })
 
 test_that("snapshot chunk size must be positive", {

--- a/R-cdstoolchain/pseudonym/tests/testthat/test-pseudonymize-snapshot-streaming.R
+++ b/R-cdstoolchain/pseudonym/tests/testthat/test-pseudonymize-snapshot-streaming.R
@@ -107,7 +107,7 @@ test_that("shared medication resolution query traverses the reference graph", {
   expect_match(query, "UNION ALL", fixed = TRUE)
   expect_match(query, "medication_edges AS", fixed = TRUE)
   expect_match(query, "medication_walk(root_medication_id, medication_id)", fixed = TRUE)
-  expect_match(query, "FROM medication_walk\nJOIN medication_edges", fixed = TRUE)
+  expect_match(query, "FROM medication_walk\n  JOIN medication_edges", fixed = TRUE)
   expect_match(query, "missing_medication", fixed = TRUE)
   expect_match(query, "no_reachable_code", fixed = TRUE)
 })
@@ -141,6 +141,46 @@ test_that("shared medication resolution keeps direct codes without ingredient re
   expect_match(query, "medication_edges AS", fixed = TRUE)
   expect_match(query, "WHERE FALSE", fixed = TRUE)
   expect_match(query, "medication_code_values AS", fixed = TRUE)
+})
+
+test_that("composed medication SQL keeps nested queries indented", {
+  query <- buildSnapshotMedicationResolutionQuery(
+    DBI::ANSI(),
+    c(
+      "SELECT 'med-1'::text AS root_medication_id",
+      "SELECT 'med-2'::text AS root_medication_id"
+    ),
+    '"db2dataprocessor_out"."v_medication"'
+  )
+
+  expect_match(
+    query,
+    paste0(
+      "medication_nodes AS (\n",
+      "  SELECT DISTINCT \"med_id\"::text AS medication_id\n",
+      "  FROM \"db2dataprocessor_out\".\"v_medication\""
+    ),
+    fixed = TRUE
+  )
+  expect_match(
+    query,
+    paste0(
+      "FROM (\n",
+      "    SELECT 'med-1'::text AS root_medication_id\n",
+      "    UNION ALL\n",
+      "    SELECT 'med-2'::text AS root_medication_id\n",
+      "  ) medication_root_candidates"
+    ),
+    fixed = TRUE
+  )
+  expect_match(
+    query,
+    paste0(
+      "LEFT JOIN medication_codes\n",
+      "  ON medication_codes.root_medication_id = "
+    ),
+    fixed = TRUE
+  )
 })
 
 test_that("medication source query supports every configured reference table", {


### PR DESCRIPTION
## Summary

- resolve Medication codes transitively in PostgreSQL during snapshot streaming
- prepare one indexed temporary resolution per snapshot variant and reuse it for Request, Statement, and Administration
- keep direct codes, deduplicate reachable code/system pairs, and terminate cyclic references
- report missing Medications and reference chains without reachable codes with bounded review details
- document recursive Medication enrichment

## Verification

- 246 pseudonym package tests pass
- PostgreSQL integration check covers shared resolution across all three resources as well as direct, deep, branched, cyclic, missing, and code-free reference chains
- local PostgreSQL benchmark with 300,000 overlapping source rows and 10,000 depth-2 chains: 3.44 s repeated vs. 2.24 s shared (1.54x faster)

Closes #1331