### PR TITLE
Add Phase B end metadata without stopping MRP calculations

### DIFF
--- a/R-dataprocessor/dataprocessor/R/01_Shared_Functions.R
+++ b/R-dataprocessor/dataprocessor/R/01_Shared_Functions.R
@@ -2,9 +2,11 @@
 #'
 #' Validates ward phase definitions loaded from global variables with the prefix
 #' `PHASES_WARD`. Each definition must contain exactly one non-empty
-#' `ward_name`, exactly one `phase_a_start`, and at most one `phase_b_start`.
+#' `ward_name`, exactly one `phase_a_start`, and at most one `phase_b_start` and
+#' `phase_b_end`.
 #' The function also checks that all timestamps have a valid format and that
-#' `phase_b_start`, if present, is later than `phase_a_start`.
+#' `phase_b_start`, if present, is later than `phase_a_start`. `phase_b_end`
+#' requires `phase_b_start` and must be later than it.
 #'
 #' @param timezone A character string defining the timezone used for parsing
 #'   phase timestamps.
@@ -61,7 +63,7 @@ validateWardPhases <- function(timezone = GLOBAL_TIMEZONE) {
   parsed_records <- tryCatch(
     etlutils::parseStructuredConfigDefinitions(
       definitions = list(ward_phases),
-      allowed_key_pattern = "ward_name|phase_a_start|phase_b_start",
+      allowed_key_pattern = "ward_name|phase_a_start|phase_b_start|phase_b_end",
       allow_plus = FALSE
     ),
     error = function(e) {
@@ -87,6 +89,12 @@ validateWardPhases <- function(timezone = GLOBAL_TIMEZONE) {
     if (sum(keys == "phase_b_start") > 1L) {
       stop(msg_prefix, "Entry ", entry_name, " must contain at most one phase_b_start.")
     }
+    if (sum(keys == "phase_b_end") > 1L) {
+      stop(msg_prefix, "Entry ", entry_name, " must contain at most one phase_b_end.")
+    }
+    if (any(keys == "phase_b_end") && !any(keys == "phase_b_start")) {
+      stop(msg_prefix, "Entry ", entry_name, " must contain phase_b_start when phase_b_end is set.")
+    }
 
     ward_name <- values[keys == "ward_name"]
     if (trimws(ward_name) == "") {
@@ -110,6 +118,16 @@ validateWardPhases <- function(timezone = GLOBAL_TIMEZONE) {
       }
       if (!(phase_a < phase_b)) {
         stop(msg_prefix, "phase_a_start must be earlier than phase_b_start in entry ", entry_name, ".")
+      }
+      if (any(keys == "phase_b_end")) {
+        phase_b_end_raw <- values[keys == "phase_b_end"]
+        phase_b_end <- etlutils::parseTimestamp(phase_b_end_raw, timezone = timezone)
+        if (is.na(phase_b_end)) {
+          stop(msg_prefix, "phase_b_end is not a valid timestamp in entry ", entry_name, ": ", phase_b_end_raw)
+        }
+        if (!(phase_b < phase_b_end)) {
+          stop(msg_prefix, "phase_b_start must be earlier than phase_b_end in entry ", entry_name, ".")
+        }
       }
     }
     ward_names <- c(ward_names, ward_name)

--- a/R-dataprocessor/dataprocessor/R/01_Shared_Functions.R
+++ b/R-dataprocessor/dataprocessor/R/01_Shared_Functions.R
@@ -2,11 +2,11 @@
 #'
 #' Validates ward phase definitions loaded from global variables with the prefix
 #' `PHASES_WARD`. Each definition must contain exactly one non-empty
-#' `ward_name`, exactly one `phase_a_start`, and at most one `phase_b_start` and
-#' `phase_b_end`.
+#' `ward_name`, exactly one `phase_a_start`, and at most one `phase_b_start`.
 #' The function also checks that all timestamps have a valid format and that
-#' `phase_b_start`, if present, is later than `phase_a_start`. `phase_b_end`
-#' requires `phase_b_start` and must be later than it.
+#' If `phase_b_start` is present, exactly one `phase_b_end` is required. All phase
+#' timestamps must be valid, `phase_b_start` must be later than `phase_a_start`,
+#' and `phase_b_end` must be later than `phase_b_start`.
 #'
 #' @param timezone A character string defining the timezone used for parsing
 #'   phase timestamps.
@@ -19,7 +19,8 @@
 #' PHASES_WARD_1 <- c(
 #'   "ward_name = 'Station 1'",
 #'   "phase_a_start = '2026-01-11 10:00:00'",
-#'   "phase_b_start = '2026-01-21 10:00:00'"
+#'   "phase_b_start = '2026-01-21 10:00:00'",
+#'   "phase_b_end = '2026-04-21 10:00:00'"
 #' )
 #'
 #' PHASES_WARD_2 <- c(
@@ -118,6 +119,9 @@ validateWardPhases <- function(timezone = GLOBAL_TIMEZONE) {
       }
       if (!(phase_a < phase_b)) {
         stop(msg_prefix, "phase_a_start must be earlier than phase_b_start in entry ", entry_name, ".")
+      }
+      if (!any(keys == "phase_b_end")) {
+        stop(msg_prefix, "Entry ", entry_name, " must contain phase_b_end when phase_b_start is set.")
       }
       if (any(keys == "phase_b_end")) {
         phase_b_end_raw <- values[keys == "phase_b_end"]

--- a/R-dataprocessor/dataprocessor/tests/testthat/test-study-phases.R
+++ b/R-dataprocessor/dataprocessor/tests/testthat/test-study-phases.R
@@ -1,54 +1,29 @@
 source(testthat::test_path("../../../submodules/00_Submodules_Shared_Functions/Study_Phases.R"))
 
-testthat::test_that("Phase B activity is evaluated per ward", {
+testthat::test_that("phase_b_end does not stop Phase B behavior", {
   assign(
     "PHASES_WARD_1",
     c(
-      "ward_name = 'Ended ward'",
+      "ward_name = 'Station 1'",
       "phase_a_start = '2026-01-01'",
       "phase_b_start = '2026-02-01'",
       "phase_b_end = '2026-03-01'"
     ),
     envir = .GlobalEnv
   )
-  assign(
-    "PHASES_WARD_2",
-    c(
-      "ward_name = 'Active ward'",
-      "phase_a_start = '2026-01-01'",
-      "phase_b_start = '2026-02-01'"
-    ),
-    envir = .GlobalEnv
-  )
-  on.exit(
-    rm(list = c("PHASES_WARD_1", "PHASES_WARD_2"), envir = .GlobalEnv),
-    add = TRUE
-  )
+  on.exit(rm(list = "PHASES_WARD_1", envir = .GlobalEnv), add = TRUE)
 
-  timestamp <- etlutils::parseTimestamp("2026-04-01")
-  testthat::expect_false(isPhaseBActiveForWard("Ended ward", timestamp))
-  testthat::expect_true(isPhaseBActiveForWard("Active ward", timestamp))
-
-  ended_ward_rows <- data.frame(
-    fall_studienphase = "NoPhaseActive",
-    fall_station = "Ended ward"
+  testthat::expect_identical(
+    getStudyPhase("Station 1", etlutils::parseTimestamp("2026-01-15")),
+    "PhaseA"
   )
-  active_ward_rows <- data.frame(
-    fall_studienphase = "PhaseB",
-    fall_station = "Active ward"
+  testthat::expect_identical(
+    getStudyPhase("Station 1", etlutils::parseTimestamp("2026-02-01")),
+    "PhaseB"
   )
-  testthat::expect_false(isMRPCalculationActiveForFallFeRows(ended_ward_rows, timestamp))
-  testthat::expect_true(isMRPCalculationActiveForFallFeRows(active_ward_rows, timestamp))
-  testthat::expect_true(isMRPCalculationActiveForFallFeRows(
-    rbind(ended_ward_rows, active_ward_rows),
-    timestamp
-  ))
-})
-
-testthat::test_that("PhaseBTest rows remain eligible", {
-  fall_fe_rows <- data.frame(
-    fall_studienphase = "PhaseBTest",
-    fall_station = "Unconfigured test ward"
+  testthat::expect_identical(
+    getStudyPhase("Station 1", etlutils::parseTimestamp("2026-04-01")),
+    "PhaseB"
   )
-  testthat::expect_true(isMRPCalculationActiveForFallFeRows(fall_fe_rows))
+  testthat::expect_true(isPhaseBActive(etlutils::parseTimestamp("2026-04-01")))
 })

--- a/R-dataprocessor/dataprocessor/tests/testthat/test-study-phases.R
+++ b/R-dataprocessor/dataprocessor/tests/testthat/test-study-phases.R
@@ -1,0 +1,54 @@
+source(testthat::test_path("../../../submodules/00_Submodules_Shared_Functions/Study_Phases.R"))
+
+testthat::test_that("Phase B activity is evaluated per ward", {
+  assign(
+    "PHASES_WARD_1",
+    c(
+      "ward_name = 'Ended ward'",
+      "phase_a_start = '2026-01-01'",
+      "phase_b_start = '2026-02-01'",
+      "phase_b_end = '2026-03-01'"
+    ),
+    envir = .GlobalEnv
+  )
+  assign(
+    "PHASES_WARD_2",
+    c(
+      "ward_name = 'Active ward'",
+      "phase_a_start = '2026-01-01'",
+      "phase_b_start = '2026-02-01'"
+    ),
+    envir = .GlobalEnv
+  )
+  on.exit(
+    rm(list = c("PHASES_WARD_1", "PHASES_WARD_2"), envir = .GlobalEnv),
+    add = TRUE
+  )
+
+  timestamp <- etlutils::parseTimestamp("2026-04-01")
+  testthat::expect_false(isPhaseBActiveForWard("Ended ward", timestamp))
+  testthat::expect_true(isPhaseBActiveForWard("Active ward", timestamp))
+
+  ended_ward_rows <- data.frame(
+    fall_studienphase = "NoPhaseActive",
+    fall_station = "Ended ward"
+  )
+  active_ward_rows <- data.frame(
+    fall_studienphase = "PhaseB",
+    fall_station = "Active ward"
+  )
+  testthat::expect_false(isMRPCalculationActiveForFallFeRows(ended_ward_rows, timestamp))
+  testthat::expect_true(isMRPCalculationActiveForFallFeRows(active_ward_rows, timestamp))
+  testthat::expect_true(isMRPCalculationActiveForFallFeRows(
+    rbind(ended_ward_rows, active_ward_rows),
+    timestamp
+  ))
+})
+
+testthat::test_that("PhaseBTest rows remain eligible", {
+  fall_fe_rows <- data.frame(
+    fall_studienphase = "PhaseBTest",
+    fall_station = "Unconfigured test ward"
+  )
+  testthat::expect_true(isMRPCalculationActiveForFallFeRows(fall_fe_rows))
+})

--- a/R-dataprocessor/dataprocessor/tests/testthat/test-validateWardPhases.R
+++ b/R-dataprocessor/dataprocessor/tests/testthat/test-validateWardPhases.R
@@ -135,3 +135,27 @@ testthat::test_that("validateWardPhases rejects phase_b_start earlier than phase
   on.exit(rm(list = "PHASES_WARD_1", envir = .GlobalEnv), add = TRUE)
   testthat::expect_error(validateWardPhases(timezone = "UTC"), "phase_a_start must be earlier than phase_b_start")
 })
+
+testthat::test_that("validateWardPhases accepts phase_b_end after phase_b_start", {
+  assign("PHASES_WARD_1", c("ward_name = 'Station 1'", "phase_a_start = '2026-01-11'", "phase_b_start = '2026-01-12'", "phase_b_end = '2026-04-21'"), envir = .GlobalEnv)
+  on.exit(rm(list = "PHASES_WARD_1", envir = .GlobalEnv), add = TRUE)
+  testthat::expect_true(validateWardPhases(timezone = "UTC"))
+})
+
+testthat::test_that("validateWardPhases rejects phase_b_end without phase_b_start", {
+  assign("PHASES_WARD_1", c("ward_name = 'Station 1'", "phase_a_start = '2026-01-11'", "phase_b_end = '2026-04-21'"), envir = .GlobalEnv)
+  on.exit(rm(list = "PHASES_WARD_1", envir = .GlobalEnv), add = TRUE)
+  testthat::expect_error(validateWardPhases(timezone = "UTC"), "must contain phase_b_start")
+})
+
+testthat::test_that("validateWardPhases rejects invalid phase_b_end", {
+  assign("PHASES_WARD_1", c("ward_name = 'Station 1'", "phase_a_start = '2026-01-11'", "phase_b_start = '2026-01-12'", "phase_b_end = 'invalid'"), envir = .GlobalEnv)
+  on.exit(rm(list = "PHASES_WARD_1", envir = .GlobalEnv), add = TRUE)
+  testthat::expect_error(validateWardPhases(timezone = "UTC"), "phase_b_end is not a valid timestamp")
+})
+
+testthat::test_that("validateWardPhases rejects phase_b_end at phase_b_start", {
+  assign("PHASES_WARD_1", c("ward_name = 'Station 1'", "phase_a_start = '2026-01-11'", "phase_b_start = '2026-01-12'", "phase_b_end = '2026-01-12'"), envir = .GlobalEnv)
+  on.exit(rm(list = "PHASES_WARD_1", envir = .GlobalEnv), add = TRUE)
+  testthat::expect_error(validateWardPhases(timezone = "UTC"), "phase_b_start must be earlier than phase_b_end")
+})

--- a/R-dataprocessor/dataprocessor/tests/testthat/test-validateWardPhases.R
+++ b/R-dataprocessor/dataprocessor/tests/testthat/test-validateWardPhases.R
@@ -4,8 +4,8 @@
 
 # Accepts multiple valid definitions
 testthat::test_that("validateWardPhases returns TRUE for valid definitions", {
-  assign("PHASES_WARD_1", c("ward_name = 'Station 1'", "phase_a_start = '2026-01-11 10:00:00'", "phase_b_start = '2026-01-21 10:00:00'"), envir = .GlobalEnv)
-  assign("PHASES_WARD_2", c("ward_name = 'Station 2'", "phase_a_start = '2026-01-11'", "phase_b_start = '2026-01-12'"), envir = .GlobalEnv)
+  assign("PHASES_WARD_1", c("ward_name = 'Station 1'", "phase_a_start = '2026-01-11 10:00:00'", "phase_b_start = '2026-01-21 10:00:00'", "phase_b_end = '2026-04-21 10:00:00'"), envir = .GlobalEnv)
+  assign("PHASES_WARD_2", c("ward_name = 'Station 2'", "phase_a_start = '2026-01-11'", "phase_b_start = '2026-01-12'", "phase_b_end = '2026-04-12'"), envir = .GlobalEnv)
   on.exit(rm(list = c("PHASES_WARD_1", "PHASES_WARD_2"), envir = .GlobalEnv), add = TRUE)
   testthat::expect_true(validateWardPhases(timezone = "UTC"))
 })
@@ -19,7 +19,7 @@ testthat::test_that("validateWardPhases accepts missing phase_b_start", {
 
 # Accepts date-only and minute-only timestamps
 testthat::test_that("validateWardPhases accepts date without time and date with minutes only", {
-  assign("PHASES_WARD_1", c("ward_name = 'Station 1'", "phase_a_start = '2026-01-11'", "phase_b_start = '2026-01-11 10:00'"), envir = .GlobalEnv)
+  assign("PHASES_WARD_1", c("ward_name = 'Station 1'", "phase_a_start = '2026-01-11'", "phase_b_start = '2026-01-11 10:00'", "phase_b_end = '2026-04-21'"), envir = .GlobalEnv)
   on.exit(rm(list = "PHASES_WARD_1", envir = .GlobalEnv), add = TRUE)
   testthat::expect_true(validateWardPhases(timezone = "UTC"))
 })
@@ -33,7 +33,7 @@ testthat::test_that("validateWardPhases rejects equal phase_a_start and phase_b_
 
 # Accepts whitespace variations
 testthat::test_that("validateWardPhases accepts whitespace variations", {
-  assign("PHASES_WARD_1", c("   ward_name     =    'Station 1'   ", " phase_a_start   =   '2026-01-11 10:00' ", " phase_b_start = '2026-01-21 10:00:00'   "), envir = .GlobalEnv)
+  assign("PHASES_WARD_1", c("   ward_name     =    'Station 1'   ", " phase_a_start   =   '2026-01-11 10:00' ", " phase_b_start = '2026-01-21 10:00:00'   ", " phase_b_end = '2026-04-21 10:00:00'   "), envir = .GlobalEnv)
   on.exit(rm(list = "PHASES_WARD_1", envir = .GlobalEnv), add = TRUE)
   testthat::expect_true(validateWardPhases(timezone = "UTC"))
 })
@@ -158,4 +158,11 @@ testthat::test_that("validateWardPhases rejects phase_b_end at phase_b_start", {
   assign("PHASES_WARD_1", c("ward_name = 'Station 1'", "phase_a_start = '2026-01-11'", "phase_b_start = '2026-01-12'", "phase_b_end = '2026-01-12'"), envir = .GlobalEnv)
   on.exit(rm(list = "PHASES_WARD_1", envir = .GlobalEnv), add = TRUE)
   testthat::expect_error(validateWardPhases(timezone = "UTC"), "phase_b_start must be earlier than phase_b_end")
+})
+
+
+testthat::test_that("validateWardPhases rejects missing phase_b_end", {
+  assign("PHASES_WARD_1", c("ward_name = 'Station 1'", "phase_a_start = '2026-01-11'", "phase_b_start = '2026-01-12'"), envir = .GlobalEnv)
+  on.exit(rm(list = "PHASES_WARD_1", envir = .GlobalEnv), add = TRUE)
+  testthat::expect_error(validateWardPhases(timezone = "UTC"), "must contain phase_b_end when phase_b_start is set")
 })

--- a/R-dataprocessor/dataprocessor_config.toml
+++ b/R-dataprocessor/dataprocessor_config.toml
@@ -50,9 +50,9 @@ MAX_DIR_COUNT = 5
 
 #################
 # Define the phase times for every ward. ward_name and phase_a_start are
-# mandatory; phase_b_start and phase_b_end are optional. Without phase_b_start,
-# phase A never ends and phase B never starts. Without phase_b_end, phase B does
-# not end. At phase_b_end, MRP calculation stops while case imports continue.
+# mandatory. phase_b_start is optional. If phase_b_start is set, phase_b_end is
+# mandatory metadata for later study analyses. phase_b_end does not stop MRP
+# calculation.
 # The ward_name must be exactly the same as in the ENCOUNTER_FILTER_PATTERNS in the cds2db_config.toml.
 # The defined ward names are also used to restrict reporting and analysis to INTERPOLAR wards.
 #################
@@ -66,7 +66,8 @@ PHASES_WARD_1 = [
 PHASES_WARD_2 = [
   "ward_name     = 'Station 2'",
   "phase_a_start = '2026-01-11'", # same as 2026-01-11 00:00:00
-  "phase_b_start = '2026-01-12'"
+  "phase_b_start = '2026-01-12'",
+  "phase_b_end = '2026-01-13 10:00:00'"
 ]
 
 PHASES_WARD_3 = [

--- a/R-dataprocessor/dataprocessor_config.toml
+++ b/R-dataprocessor/dataprocessor_config.toml
@@ -49,17 +49,18 @@ MAX_DIR_COUNT = 5
 #]
 
 #################
-# Define the phase start times for every ward. ward_name and phase_a_start is
-# mandatory, phase_b_start is optional. If phase_b_start is not specified, then
-# the phase A never ends and phase B never starts. If phase_b_start is specified,
-# then phase A ends one second before the start of phase B.
+# Define the phase times for every ward. ward_name and phase_a_start are
+# mandatory; phase_b_start and phase_b_end are optional. Without phase_b_start,
+# phase A never ends and phase B never starts. Without phase_b_end, phase B does
+# not end. At phase_b_end, MRP calculation stops while case imports continue.
 # The ward_name must be exactly the same as in the ENCOUNTER_FILTER_PATTERNS in the cds2db_config.toml.
 # The defined ward names are also used to restrict reporting and analysis to INTERPOLAR wards.
 #################
 PHASES_WARD_1 = [
   "ward_name = 'Station 1'",
   "phase_a_start = '2026-01-11 10:00:00'",
-  "phase_b_start = '2026-01-21 10:00:00'"
+  "phase_b_start = '2026-01-21 10:00:00'",
+  "phase_b_end = '2026-05-22 10:00:00'"
 ]
 
 PHASES_WARD_2 = [

--- a/R-dataprocessor/dataprocessor_config_example.toml
+++ b/R-dataprocessor/dataprocessor_config_example.toml
@@ -28,6 +28,26 @@ MAX_DIR_COUNT = 5
 [analyse]
 
 #################
+# Define the phase times for every ward. ward_name and phase_a_start are
+# mandatory; phase_b_start and phase_b_end are optional. Without phase_b_start,
+# phase A never ends and phase B never starts. Without phase_b_end, phase B does
+# not end. At phase_b_end, MRP calculation stops while case imports continue.
+# The ward_name must be exactly the same as in the ENCOUNTER_FILTER_PATTERNS in
+# the cds2db_config.toml.
+#################
+PHASES_WARD_1 = [
+  "ward_name = 'Station 1'",
+  "phase_a_start = '2026-01-11 10:00:00'",
+  "phase_b_start = '2026-01-21 10:00:00'",
+  #"phase_b_end = '2026-04-21 10:00:00'"
+]
+
+PHASES_WARD_2 = [
+  "ward_name = 'Station 2'",
+  "phase_a_start = '2026-01-11'"
+]
+
+#################
 # Filter for the displayable PID
 # ------------------------------
 # To filter the correct patient ID from the hospital information system for the

--- a/R-dataprocessor/dataprocessor_config_example.toml
+++ b/R-dataprocessor/dataprocessor_config_example.toml
@@ -29,9 +29,9 @@ MAX_DIR_COUNT = 5
 
 #################
 # Define the phase times for every ward. ward_name and phase_a_start are
-# mandatory; phase_b_start and phase_b_end are optional. Without phase_b_start,
-# phase A never ends and phase B never starts. Without phase_b_end, phase B does
-# not end. At phase_b_end, MRP calculation stops while case imports continue.
+# mandatory. phase_b_start is optional. If phase_b_start is set, phase_b_end is
+# mandatory metadata for later study analyses. phase_b_end does not stop MRP
+# calculation.
 # The ward_name must be exactly the same as in the ENCOUNTER_FILTER_PATTERNS in
 # the cds2db_config.toml.
 #################
@@ -39,7 +39,7 @@ PHASES_WARD_1 = [
   "ward_name = 'Station 1'",
   "phase_a_start = '2026-01-11 10:00:00'",
   "phase_b_start = '2026-01-21 10:00:00'",
-  #"phase_b_end = '2026-04-21 10:00:00'"
+  "phase_b_end = '2026-04-21 10:00:00'"
 ]
 
 PHASES_WARD_2 = [

--- a/R-dataprocessor/submodules/00_Submodules_Shared_Functions/Study_Phases.R
+++ b/R-dataprocessor/submodules/00_Submodules_Shared_Functions/Study_Phases.R
@@ -14,20 +14,6 @@ extractSingleEntryLinesValue <- function(entry_lines, key) {
 }
 
 #
-# Return the phase definition for a ward, or NULL if the ward is not configured.
-#
-getWardPhaseDefinition <- function(ward_name) {
-  ward_phases <- etlutils::getGlobalVariablesByPrefix("PHASES_WARD")
-  for (ward_phase in ward_phases) {
-    configured_ward_name <- extractSingleEntryLinesValue(ward_phase, "ward_name")
-    if (identical(configured_ward_name, ward_name)) {
-      return(ward_phase)
-    }
-  }
-  return(NULL)
-}
-
-#
 # Extract values for a given key from a list of character vectors. Each element of the list is expected to be a character vector of lines containing key-value pairs.
 # Returns a character vector of values corresponding to the key, excluding any NA values.
 #
@@ -53,21 +39,30 @@ getStudyPhase <- function(ward_name, date_time) {
     return("PhaseBTest")
   }
 
+  # get the index of the ward phase definition for the given ward name, return -1 if not found
+  getWardPhaseIndex <- function(ward_phases, ward_name) {
+    for (i in seq_along(ward_phases)) {
+      lines <- ward_phases[[i]]
+      configured_ward_name <- extractSingleEntryLinesValue(lines, "ward_name")
+      if (identical(configured_ward_name, ward_name)) {
+        return(i)
+      }
+    }
+    return(-1)
+  }
+
   # determine the phase for the given ward and date_time based on the ward phases defined in the configuration.
   # If no phase is active for the given date_time, return "NoPhaseActive".
   phase <- NA_character_ # indicates that the ward is not defined in the configuration
-  ward_phase <- getWardPhaseDefinition(ward_name)
-  if (!is.null(ward_phase)) {
+  ward_phases <- etlutils::getGlobalVariablesByPrefix("PHASES_WARD")
+  phase_def_index <- getWardPhaseIndex(ward_phases, ward_name)
+  if (phase_def_index != -1L) {
     phase <- "NoPhaseActive" # indicates that the ward is defined in the configuration but no phase is active for the given date_time
-    lines <- ward_phase
+    lines <- ward_phases[[phase_def_index]]
     phase_b_start <- etlutils::parseTimestamp(extractSingleEntryLinesValue(lines, "phase_b_start"))
-    phase_b_end <- etlutils::parseTimestamp(extractSingleEntryLinesValue(lines, "phase_b_end"))
-    if (
-      !is.na(phase_b_start) && date_time >= phase_b_start &&
-      (is.na(phase_b_end) || date_time < phase_b_end)
-    ) {
+    if (!is.na(phase_b_start) && date_time >= phase_b_start) {
       phase <- "PhaseB"
-    } else if (is.na(phase_b_start) || date_time < phase_b_start) {
+    } else {
       phase_a_start <- etlutils::parseTimestamp(extractSingleEntryLinesValue(lines, "phase_a_start"))
       if (date_time >= phase_a_start) {
         phase <- "PhaseA"
@@ -79,51 +74,19 @@ getStudyPhase <- function(ward_name, date_time) {
 }
 
 #
-# Check whether Phase B is active for a ward at a timestamp.
-#
-isPhaseBActiveForWard <- function(ward_name, timestamp = etlutils::as.POSIXctWithTimezone(Sys.time())) {
-  if (etlutils::isDefinedAndNotEmpty("WARDS_PHASE_B_TEST") && ward_name %in% WARDS_PHASE_B_TEST) {
-    return(TRUE)
-  }
-
-  ward_phase <- getWardPhaseDefinition(ward_name)
-  if (is.null(ward_phase)) {
-    return(FALSE)
-  }
-
-  phase_b_start <- etlutils::parseTimestamp(
-    extractSingleEntryLinesValue(ward_phase, "phase_b_start")
-  )
-  phase_b_end <- etlutils::parseTimestamp(extractSingleEntryLinesValue(ward_phase, "phase_b_end"))
-  return(
-    !is.na(phase_b_start) && phase_b_start <= timestamp &&
-      (is.na(phase_b_end) || timestamp < phase_b_end)
-  )
-}
-
-#
-# Check whether MRP calculation is active for any ward represented by fall_fe rows.
-#
-isMRPCalculationActiveForFallFeRows <- function(
-  fall_fe_rows,
-  timestamp = etlutils::as.POSIXctWithTimezone(Sys.time())
-) {
-  study_phases <- fall_fe_rows$fall_studienphase
-  if (any(!is.na(study_phases) & study_phases == "PhaseBTest")) {
-    return(TRUE)
-  }
-
-  ward_names <- unique(stats::na.omit(fall_fe_rows$fall_station))
-  return(any(vapply(ward_names, isPhaseBActiveForWard, logical(1), timestamp = timestamp)))
-}
-
-#
 # Check if the study has Phase B wards defined in the configuration.
 #
 isPhaseBActive <- function(timestamp = etlutils::as.POSIXctWithTimezone(Sys.time())) {
+  # phase_b_end is study metadata and intentionally does not stop MRP calculation.
   ward_phases <- etlutils::getGlobalVariablesByPrefix("PHASES_WARD")
-  ward_names <- extractValues(ward_phases, "ward_name")
-  return(any(vapply(ward_names, isPhaseBActiveForWard, logical(1), timestamp = timestamp)))
+  phase_b_starts <- extractValues(ward_phases, "phase_b_start")
+  for (phase_b_start in phase_b_starts) {
+    phase_b_start <- etlutils::parseTimestamp(phase_b_start)
+    if (phase_b_start <= timestamp) {
+      return(TRUE)
+    }
+  }
+  return(FALSE)
 }
 
 #

--- a/R-dataprocessor/submodules/00_Submodules_Shared_Functions/Study_Phases.R
+++ b/R-dataprocessor/submodules/00_Submodules_Shared_Functions/Study_Phases.R
@@ -14,6 +14,20 @@ extractSingleEntryLinesValue <- function(entry_lines, key) {
 }
 
 #
+# Return the phase definition for a ward, or NULL if the ward is not configured.
+#
+getWardPhaseDefinition <- function(ward_name) {
+  ward_phases <- etlutils::getGlobalVariablesByPrefix("PHASES_WARD")
+  for (ward_phase in ward_phases) {
+    configured_ward_name <- extractSingleEntryLinesValue(ward_phase, "ward_name")
+    if (identical(configured_ward_name, ward_name)) {
+      return(ward_phase)
+    }
+  }
+  return(NULL)
+}
+
+#
 # Extract values for a given key from a list of character vectors. Each element of the list is expected to be a character vector of lines containing key-value pairs.
 # Returns a character vector of values corresponding to the key, excluding any NA values.
 #
@@ -39,30 +53,21 @@ getStudyPhase <- function(ward_name, date_time) {
     return("PhaseBTest")
   }
 
-  # get the index of the ward phase definition for the given ward name, return -1 if not found
-  getWardPhaseIndex <- function(ward_phases, ward_name) {
-    for (i in seq_along(ward_phases)) {
-      lines <- ward_phases[[i]]
-      configured_ward_name <- extractSingleEntryLinesValue(lines, "ward_name")
-      if (identical(configured_ward_name, ward_name)) {
-        return(i)
-      }
-    }
-    return(-1)
-  }
-
   # determine the phase for the given ward and date_time based on the ward phases defined in the configuration.
   # If no phase is active for the given date_time, return "NoPhaseActive".
   phase <- NA_character_ # indicates that the ward is not defined in the configuration
-  ward_phases <- etlutils::getGlobalVariablesByPrefix("PHASES_WARD")
-  phase_def_index <- getWardPhaseIndex(ward_phases, ward_name)
-  if (phase_def_index != -1L) {
+  ward_phase <- getWardPhaseDefinition(ward_name)
+  if (!is.null(ward_phase)) {
     phase <- "NoPhaseActive" # indicates that the ward is defined in the configuration but no phase is active for the given date_time
-    lines <- ward_phases[[phase_def_index]]
+    lines <- ward_phase
     phase_b_start <- etlutils::parseTimestamp(extractSingleEntryLinesValue(lines, "phase_b_start"))
-    if (!is.na(phase_b_start) && date_time >= phase_b_start) {
+    phase_b_end <- etlutils::parseTimestamp(extractSingleEntryLinesValue(lines, "phase_b_end"))
+    if (
+      !is.na(phase_b_start) && date_time >= phase_b_start &&
+      (is.na(phase_b_end) || date_time < phase_b_end)
+    ) {
       phase <- "PhaseB"
-    } else {
+    } else if (is.na(phase_b_start) || date_time < phase_b_start) {
       phase_a_start <- etlutils::parseTimestamp(extractSingleEntryLinesValue(lines, "phase_a_start"))
       if (date_time >= phase_a_start) {
         phase <- "PhaseA"
@@ -74,22 +79,51 @@ getStudyPhase <- function(ward_name, date_time) {
 }
 
 #
+# Check whether Phase B is active for a ward at a timestamp.
+#
+isPhaseBActiveForWard <- function(ward_name, timestamp = etlutils::as.POSIXctWithTimezone(Sys.time())) {
+  if (etlutils::isDefinedAndNotEmpty("WARDS_PHASE_B_TEST") && ward_name %in% WARDS_PHASE_B_TEST) {
+    return(TRUE)
+  }
+
+  ward_phase <- getWardPhaseDefinition(ward_name)
+  if (is.null(ward_phase)) {
+    return(FALSE)
+  }
+
+  phase_b_start <- etlutils::parseTimestamp(
+    extractSingleEntryLinesValue(ward_phase, "phase_b_start")
+  )
+  phase_b_end <- etlutils::parseTimestamp(extractSingleEntryLinesValue(ward_phase, "phase_b_end"))
+  return(
+    !is.na(phase_b_start) && phase_b_start <= timestamp &&
+      (is.na(phase_b_end) || timestamp < phase_b_end)
+  )
+}
+
+#
+# Check whether MRP calculation is active for any ward represented by fall_fe rows.
+#
+isMRPCalculationActiveForFallFeRows <- function(
+  fall_fe_rows,
+  timestamp = etlutils::as.POSIXctWithTimezone(Sys.time())
+) {
+  study_phases <- fall_fe_rows$fall_studienphase
+  if (any(!is.na(study_phases) & study_phases == "PhaseBTest")) {
+    return(TRUE)
+  }
+
+  ward_names <- unique(stats::na.omit(fall_fe_rows$fall_station))
+  return(any(vapply(ward_names, isPhaseBActiveForWard, logical(1), timestamp = timestamp)))
+}
+
+#
 # Check if the study has Phase B wards defined in the configuration.
 #
-isPhaseBActive <- function(timestamp =  etlutils::as.POSIXctWithTimezone(Sys.time())) {
-  # get all phase_b_start values from the ward phases and check if any is before the given timestamp
+isPhaseBActive <- function(timestamp = etlutils::as.POSIXctWithTimezone(Sys.time())) {
   ward_phases <- etlutils::getGlobalVariablesByPrefix("PHASES_WARD")
-  phase_b_starts <- extractValues(ward_phases, "phase_b_start")
-  # convert to timestamp via parseTimestamp and check if any is before the given timestamp
-  # the timestamp cannot be empty or invalid format because this is already checked in validateWardPhase
-  # which is called in before this function is called
-  for (phase_b_start in phase_b_starts) {
-    phase_b_start <- etlutils::parseTimestamp(phase_b_start)
-    if (phase_b_start <= timestamp) {
-      return(TRUE)
-    }
-  }
-  return(FALSE)
+  ward_names <- extractValues(ward_phases, "ward_name")
+  return(any(vapply(ward_names, isPhaseBActiveForWard, logical(1), timestamp = timestamp)))
 }
 
 #

--- a/R-dataprocessor/submodules/02_MRP_Calculation/R-MRP_Calculation/R/00_Lib_MRP_Data_Preparation.R
+++ b/R-dataprocessor/submodules/02_MRP_Calculation/R-MRP_Calculation/R/00_Lib_MRP_Data_Preparation.R
@@ -180,7 +180,10 @@ getEncountersWithoutRetrolectiveMRPEvaluationFromDB <- function() {
   }
 
   encounters <- unique(data.table::rbindlist(encounters_per_mrp_type, use.names = TRUE))
-  encounters[, study_phase := character()]
+  encounters[, `:=`(
+    study_phase = character(),
+    mrp_calculation_active = FALSE
+  )]
 
   if (nrow(encounters)) {
     #
@@ -240,10 +243,16 @@ getEncountersWithoutRetrolectiveMRPEvaluationFromDB <- function() {
         }
       }
       encounters[enc_id %in% current_enc_id, `:=`(
-        study_phase = new_study_phase
+        study_phase = new_study_phase,
+        mrp_calculation_active = isMRPCalculationActiveForFallFeRows(fall_fe_rows)
       )]
     }
   }
+
+  # Only retain encounters from wards whose Phase B is currently active.
+  # PhaseBTest encounters remain eligible independently of configured phase dates.
+  encounters <- encounters[mrp_calculation_active == TRUE]
+  encounters[, mrp_calculation_active := NULL]
 
   # TODO: Diese Funktion an die "richtige" Stelle verschieben
   getCurrentDate <- function() {

--- a/R-dataprocessor/submodules/02_MRP_Calculation/R-MRP_Calculation/R/00_Lib_MRP_Data_Preparation.R
+++ b/R-dataprocessor/submodules/02_MRP_Calculation/R-MRP_Calculation/R/00_Lib_MRP_Data_Preparation.R
@@ -180,10 +180,7 @@ getEncountersWithoutRetrolectiveMRPEvaluationFromDB <- function() {
   }
 
   encounters <- unique(data.table::rbindlist(encounters_per_mrp_type, use.names = TRUE))
-  encounters[, `:=`(
-    study_phase = character(),
-    mrp_calculation_active = FALSE
-  )]
+  encounters[, study_phase := character()]
 
   if (nrow(encounters)) {
     #
@@ -243,16 +240,10 @@ getEncountersWithoutRetrolectiveMRPEvaluationFromDB <- function() {
         }
       }
       encounters[enc_id %in% current_enc_id, `:=`(
-        study_phase = new_study_phase,
-        mrp_calculation_active = isMRPCalculationActiveForFallFeRows(fall_fe_rows)
+        study_phase = new_study_phase
       )]
     }
   }
-
-  # Only retain encounters from wards whose Phase B is currently active.
-  # PhaseBTest encounters remain eligible independently of configured phase dates.
-  encounters <- encounters[mrp_calculation_active == TRUE]
-  encounters[, mrp_calculation_active := NULL]
 
   # TODO: Diese Funktion an die "richtige" Stelle verschieben
   getCurrentDate <- function() {

--- a/R-dataprocessor/submodules/02_MRP_Calculation/Start.R
+++ b/R-dataprocessor/submodules/02_MRP_Calculation/Start.R
@@ -13,6 +13,6 @@ if (hasPhaseBOrBTestWards()) {
 
 } else {
   etlutils::runLevel2("MRP Calculation", {
-    etlutils::catWarningMessage("No Phase B wards found. MRP calculation will not be performed.\n")
+    etlutils::catWarningMessage("No active Phase B wards found. MRP calculation will not be performed.\n")
   })
 }


### PR DESCRIPTION
refs #1338

## Fachliche Klarstellung

phase_b_end dient als Metadatum für spätere Auswertungen und beendet weder Phase B noch die MRP-Berechnung.

## Änderungen

- phase_b_start bleibt optional.
- Wenn phase_b_start gesetzt ist, ist phase_b_end für den jeweiligen PHASES_WARD verpflichtend.
- phase_b_end ohne phase_b_start wird abgelehnt.
- phase_b_end muss nach phase_b_start liegen.
- MRP-Berechnungen laufen auch nach phase_b_end weiter.
- Konfigurationsbeispiele und Tests wurden entsprechend angepasst.

Die Anforderung in Issue #1338 wurde zur Klarstellung ebenfalls aktualisiert.