### PR TITLE
954 contributing + 1368 issue templates erstellen

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,49 @@
+name: Bug Report
+description: File a bug report.
+title: "[BUG]: ..."
+labels: ["bug"]
+
+body:
+- type: markdown
+  attributes:
+    value: >
+      Thank you for taking the time to file a bug report.
+      Please also check the [Issues](https://github.com/medizininformatik-initiative/INTERPOLAR/issues) and [Discussions](https://github.com/medizininformatik-initiative/INTERPOLAR/discussions) section for existing issues about the bug.
+
+- type: textarea
+  attributes:
+    label: "Describe the issue:"
+  validations:
+    required: true
+
+- type: textarea
+  attributes:
+    label: "Reproduceable commands or code example:"
+    description: >
+      A short command or code example that reproduces the problem/missing feature.
+    placeholder: |
+      << your command or code here >>
+    render: shell
+  validations:
+    required: false
+
+- type: textarea
+  attributes:
+    label: "Error message:"
+    description: >
+      Please include full error message, if any.
+    placeholder: |
+      << your error message here >>
+    render: shell
+
+- type: textarea
+  attributes:
+    label: "Version information:"
+    description: >
+      CDS Tool Chain Version or commit SHA?
+      CDS Tool Chain Database Version?
+    placeholder: |
+      CDS Tool Chain Version or commit SHA: 
+      CDS Tool Chain Database Version:
+  validations:
+    required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: INTERPOLAR IT Zulip Chat
+    url: https://mii.zulipchat.com/#narrow/channel/391087-INTERPOLAR
+    about: Please ask and answer questions here.
+  - name: INTERPOLAR IT Github Discussions
+    url: https://github.com/medizininformatik-initiative/INTERPOLAR/discussions
+    about: Please start discussions here.

--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -1,0 +1,33 @@
+name: Enhancement
+description: Make a proposal for a feature.
+title: "[ENH]: ..."
+labels: [enhancement]
+
+
+body:
+- type: markdown
+  attributes:
+    value: >
+      Check the [Contributor Guide](CONTRIBUTING.md) for more information.
+
+- type: textarea
+  attributes:
+    label: "Describe the enhancement or feature request:"
+  validations:
+    required: true
+
+- type: textarea
+  attributes:
+    label: "Link to discussion and related issues"
+    description: >
+      << link here >>
+  validations:
+    required: false
+
+- type: textarea
+  attributes:
+    label: "Proposed implementation"
+    description: >
+      << proposed implementation here >>
+  validations:
+    required: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,14 +5,22 @@ repository's code.
 
 ## Contributing
 
-Bugs, questions, and change requests can be filed as GitHub issues. Larger
-changes should be discussed in an issue or discussion before implementation so
-that the goal, scope, and expected behavior are clear.
+Bugs, questions, and change requests can be filed as 
+[GitHub issues](https://github.com/medizininformatik-initiative/INTERPOLAR/issues). 
+Please use the resp. issue templates.
+Larger changes should be discussed in an issue or 
+[discussion](https://github.com/medizininformatik-initiative/INTERPOLAR/discussions) 
+before implementation so that the goal, scope, and expected behavior are clear.
 
-Code changes are submitted through pull requests. A pull request should describe
-the purpose of the change, link relevant issues, and list the checks that were
-run. Keep pull requests focused where possible and avoid unrelated refactorings
-in the same PR.
+Code changes are submitted through 
+[pull requests](https://github.com/medizininformatik-initiative/INTERPOLAR/pulls). 
+A pull request should describe the purpose of the change, link relevant issues, 
+and list the checks that were run. Keep pull requests focused where possible and 
+avoid unrelated refactorings in the same PR.
+
+See also instructions for bugs and feature request in discussion 
+[#574](https://github.com/medizininformatik-initiative/INTERPOLAR/discussions/574) 
+(german).
 
 ## Development
 


### PR DESCRIPTION
## Summary

This PR adds GitHub issue templates and updates the contributing guide to improve the issue reporting workflow and provide better navigation for contributors.

## Changes

### Added GitHub Issue Templates

- **`bug_report.yml`**: New template for filing bug reports with fields for:
  - Issue description
  - Reproducible commands or code examples
  - Error messages
  - Version information (CDS Tool Chain version and database version)

- **`enhancement.yml`**: New template for feature proposals with fields for:
  - Enhancement or feature request description
  - Links to related discussions and issues
  - Proposed implementation

### Updated Contributing Guide

- Added clickable links to GitHub Issues, Discussions, and Pull Requests
- Added reference to issue templates for bug reports and change requests
- Added link to discussion #574 which contains additional German instructions for bugs and feature requests

## Motivation

Standardized issue templates help ensure that bug reports and enhancement requests include all necessary information for efficient triage and resolution. The updated contributing guide provides easier navigation to GitHub resources and encourages the use of the new templates.

refs #954 #1368 