### PR TITLE
Make analyses independent of database cron jobs

### DIFF
--- a/Database_Snapshot.md
+++ b/Database_Snapshot.md
@@ -259,6 +259,22 @@ geschrieben. Der Filter-Einstiegspunkt ist von Datenbankaufbau, Dump und
 Lebenszyklus getrennt. Aktuell ist dort ausdrücklich ein Durchlassfilter
 eingesetzt; die fachliche Patientenauswahl wird separat ergänzt.
 
+### Auswertungen ohne Datenbank-Cronjob
+
+Pseudonymisierte und Broad-Consent-Snapshot-Datenbanken enthalten die für die
+Versionsprüfung benötigte View `db2dataprocessor_out.v_db_parameter`. Sie stellt
+die `release_version` der jeweiligen Quelldatenbank bereit, ohne die übrige
+Datenbankkonfiguration in den Snapshot zu kopieren.
+
+Die gemeinsame Datenbankbibliothek prüft beim ersten Zugriff, ob die ausgewählte
+Datenbank schreibgeschützt ist und ob mindestens eine der für die
+INTERPOLAR-Transfersteuerung typischen Datenbankfunktionen vorhanden ist. Nur
+eine beschreibbare Datenbank mit einem solchen Funktionsmarker verwendet das
+zugehörige Locking. In schreibgeschützten Snapshot-Datenbanken und in anderen
+Datenbanken ohne diese Funktionen werden dieselben Abfragen ohne Locking
+ausgeführt. Die Auswertungen benötigen deshalb weder Adminzugang noch
+Cron-Metadaten oder einen bereits ausgeführten Cronjob.
+
 Der Prozess prüft nicht, ob die Quelle pseudonymisiert ist. Er arbeitet mit den
 in der jeweiligen Datenbank vorhandenen Patienten- und Relationsschlüsseln.
 Dadurch kann derselbe Ablauf regulär auf der pseudonymisierten und bei Bedarf

--- a/R-cdstoolchain/pseudonym/R/broad_consent_snapshot.R
+++ b/R-cdstoolchain/pseudonym/R/broad_consent_snapshot.R
@@ -247,6 +247,16 @@ createBroadConsentSnapshotDatabase <- function(
 
   result <- list()
   runPseudonymizationLogStep(2L,
+    "Read source database release version",
+    {
+      result[["release_version"]] <- getSnapshotReleaseVersion(
+        source_connection,
+        source_schema = source_schema
+      )
+    },
+    log_steps = log_steps
+  )
+  runPseudonymizationLogStep(2L,
     "Plan Broad Consent snapshot source relations",
     {
       result[["materialization_plan"]] <- getExistingSnapshotMaterializationPlan(
@@ -306,12 +316,21 @@ createBroadConsentSnapshotDatabase <- function(
   runPseudonymizationLogStep(2L,
     "Create Broad Consent snapshot views",
     {
-      result[["view_summary"]] <- createSnapshotPassthroughViews(
+      passthrough_summary <- createSnapshotPassthroughViews(
         target_connection,
         materialization_plan = result[["materialization_plan"]],
         table_schema = target_table_schema,
         view_schema = target_view_schema
       )
+      version_summary <- createSnapshotVersionView(
+        target_connection,
+        release_version = result[["release_version"]],
+        view_schema = target_view_schema
+      )
+      result[["view_summary"]] <- data.table::rbindlist(list(
+        passthrough_summary,
+        version_summary
+      ))
     },
     log_steps = log_steps
   )

--- a/R-cdstoolchain/pseudonym/R/pseudonymize_snapshot_db.R
+++ b/R-cdstoolchain/pseudonym/R/pseudonymize_snapshot_db.R
@@ -63,6 +63,72 @@ snapshotRelationExists <- function(connection, name, schema = NULL) {
   DBI::dbExistsTable(connection, relation)
 }
 
+getSnapshotReleaseVersion <- function(
+  connection,
+  source_schema = "db2dataprocessor_out"
+) {
+  source_view <- snapshotQualifiedName(connection, "v_db_parameter", source_schema)
+  statement <- paste0(
+    "SELECT parameter_value FROM ",
+    source_view,
+    " WHERE parameter_name = 'release_version'"
+  )
+  version_rows <- DBI::dbGetQuery(connection, statement)
+  if (nrow(version_rows) != 1L) {
+    stop(
+      "Source view ", source_view,
+      " must contain exactly one release_version row.",
+      call. = FALSE
+    )
+  }
+  release_version <- as.character(version_rows[["parameter_value"]][1])
+  if (is.na(release_version) || !nzchar(release_version)) {
+    stop("Source database release_version must not be empty.", call. = FALSE)
+  }
+  release_version
+}
+
+createSnapshotVersionView <- function(
+  connection,
+  release_version,
+  view_schema = "db2dataprocessor_out"
+) {
+  if (
+    length(release_version) != 1L ||
+    is.na(release_version) ||
+    !nzchar(release_version)
+  ) {
+    stop("release_version must be one non-empty value.", call. = FALSE)
+  }
+  view_name <- "v_db_parameter"
+  snapshotEnsureSchema(connection, view_schema)
+  if (snapshotRelationExists(connection, view_name, view_schema)) {
+    stop("Target view already exists: ", snapshotQualifiedName(
+      connection,
+      view_name,
+      view_schema
+    ))
+  }
+  quoted_version <- as.character(DBI::dbQuoteString(connection, release_version))
+  statement <- paste0(
+    "CREATE VIEW ",
+    snapshotQualifiedName(connection, view_name, view_schema),
+    " AS SELECT ",
+    "CAST(NULL AS integer) AS id, ",
+    "CAST('release_version' AS varchar) AS parameter_name, ",
+    "CAST(", quoted_version, " AS varchar) AS parameter_value, ",
+    "CAST('Source database release version' AS varchar) AS parameter_description, ",
+    "CAST(NULL AS timestamp) AS input_datetime, ",
+    "CAST(NULL AS timestamp) AS last_change_timestamp"
+  )
+  DBI::dbExecute(connection, statement)
+  data.table::data.table(
+    VIEW_NAME = view_name,
+    SOURCE_TABLE = NA_character_,
+    STATUS = "created"
+  )
+}
+
 #' Build Source Relation Plan for Snapshot Pseudonymization
 #'
 #' This derives the database read plan from loaded pseudonymization rules. Only
@@ -360,6 +426,16 @@ pseudonymizeSnapshotDatabase <- function(
 
   result <- list()
   runPseudonymizationLogStep(2L,
+    "Read source database release version",
+    {
+      result[["release_version"]] <- getSnapshotReleaseVersion(
+        source_connection,
+        source_schema = source_schema
+      )
+    },
+    log_steps = log_steps
+  )
+  runPseudonymizationLogStep(2L,
     "Load pseudonymization rules for snapshot DB",
     {
       result[["rules"]] <- loadPseudonymizationRules(
@@ -532,12 +608,21 @@ pseudonymizeSnapshotDatabase <- function(
   runPseudonymizationLogStep(2L,
     "Create snapshot passthrough views",
     {
-      result[["view_summary"]] <- createSnapshotPassthroughViews(
+      passthrough_summary <- createSnapshotPassthroughViews(
         target_connection,
         materialization_plan = result[["materialization_plan"]],
         table_schema = target_table_schema,
         view_schema = target_view_schema
       )
+      version_summary <- createSnapshotVersionView(
+        target_connection,
+        release_version = result[["release_version"]],
+        view_schema = target_view_schema
+      )
+      result[["view_summary"]] <- data.table::rbindlist(list(
+        passthrough_summary,
+        version_summary
+      ))
     },
     log_steps = log_steps
   )

--- a/R-cdstoolchain/pseudonym/tests/testthat/test-broad-consent-snapshot.R
+++ b/R-cdstoolchain/pseudonym/tests/testthat/test-broad-consent-snapshot.R
@@ -129,9 +129,18 @@ test_that("Broad Consent database workflow materializes and publishes its plan",
     SOURCE_TABLE = "patient",
     STATUS = "created"
   )
+  version_summary <- data.table::data.table(
+    VIEW_NAME = "v_db_parameter",
+    SOURCE_TABLE = NA_character_,
+    STATUS = "created"
+  )
 
   testthat::local_mocked_bindings(
     validateSnapshotChunkSize = function(chunk_size) as.integer(chunk_size),
+    getSnapshotReleaseVersion = function(connection, source_schema) {
+      captured$version_connection <- connection
+      "2.1.0"
+    },
     getDefaultSnapshotPseudonymizationRuleSources = function(project_root) {
       list(table_descriptions = "rules", snapshot_extensions = "extensions")
     },
@@ -187,6 +196,11 @@ test_that("Broad Consent database workflow materializes and publishes its plan",
     ) {
       captured$view_connection <- connection
       view_summary
+    },
+    createSnapshotVersionView = function(connection, release_version, view_schema) {
+      captured$version_view_connection <- connection
+      captured$release_version <- release_version
+      version_summary
     }
   )
 
@@ -202,13 +216,20 @@ test_that("Broad Consent database workflow materializes and publishes its plan",
   )
 
   expect_equal(captured$plan_connection, "source-connection")
+  expect_equal(captured$version_connection, "source-connection")
   expect_equal(captured$target_schema, "db_log")
   expect_equal(captured$temporary_source_connection, "source-connection")
   expect_equal(captured$stream_connections, c("source-connection", "target-connection"))
   expect_equal(captured$chunk_size, 2L)
   expect_equal(captured$reported_summary, summary)
   expect_equal(captured$view_connection, "target-connection")
+  expect_equal(captured$version_view_connection, "target-connection")
+  expect_equal(captured$release_version, "2.1.0")
   expect_equal(result$materialization_plan, plan)
   expect_equal(result$summary, summary)
-  expect_equal(result$view_summary, view_summary)
+  expect_equal(result$release_version, "2.1.0")
+  expect_equal(
+    result$view_summary,
+    data.table::rbindlist(list(view_summary, version_summary))
+  )
 })

--- a/R-cdstoolchain/pseudonym/tests/testthat/test-pseudonymize-snapshot-db.R
+++ b/R-cdstoolchain/pseudonym/tests/testthat/test-pseudonymize-snapshot-db.R
@@ -15,6 +15,61 @@ test_that("snapshot source session permits temporary resolution tables", {
   expect_equal(captured$statement, "SET SESSION default_transaction_read_only = off")
 })
 
+test_that("getSnapshotReleaseVersion reads exactly one source version", {
+  captured_statement <- NULL
+  testthat::local_mocked_bindings(
+    dbGetQuery = function(connection, statement) {
+      captured_statement <<- statement
+      data.frame(parameter_value = "2.1.0")
+    },
+    .package = "DBI"
+  )
+
+  result <- getSnapshotReleaseVersion(DBI::ANSI(), "db2dataprocessor_out")
+
+  expect_equal(result, "2.1.0")
+  expect_match(
+    captured_statement,
+    'FROM "db2dataprocessor_out"."v_db_parameter"',
+    fixed = TRUE
+  )
+})
+
+test_that("getSnapshotReleaseVersion rejects missing or empty versions", {
+  version_rows <- data.frame(parameter_value = character())
+  testthat::local_mocked_bindings(
+    dbGetQuery = function(connection, statement) version_rows,
+    .package = "DBI"
+  )
+
+  expect_error(getSnapshotReleaseVersion(DBI::ANSI()), "exactly one release_version")
+
+  version_rows <- data.frame(parameter_value = "")
+  expect_error(getSnapshotReleaseVersion(DBI::ANSI()), "must not be empty")
+})
+
+test_that("createSnapshotVersionView publishes the source release version", {
+  statements <- character()
+  testthat::local_mocked_bindings(
+    snapshotRelationExists = function(connection, name, schema = NULL) FALSE
+  )
+  testthat::local_mocked_bindings(
+    dbExecute = function(connection, statement) {
+      statements <<- c(statements, statement)
+      0L
+    },
+    .package = "DBI"
+  )
+
+  summary <- createSnapshotVersionView(DBI::ANSI(), "2.1'0")
+
+  expect_equal(summary$VIEW_NAME, "v_db_parameter")
+  view_statement <- statements[grepl("CREATE VIEW", statements, fixed = TRUE)]
+  expect_length(view_statement, 1L)
+  expect_match(view_statement, "CAST('2.1''0' AS varchar)", fixed = TRUE)
+  expect_match(view_statement, "AS parameter_value", fixed = TRUE)
+})
+
 test_that("getSnapshotSourceViewPlan uses described table sources only", {
   rules <- data.table::data.table(
     SOURCE_TYPE = c("table_description", "snapshot_extension", "table_description"),

--- a/R-etlutils/etlutils/R/lib_db.R
+++ b/R-etlutils/etlutils/R/lib_db.R
@@ -1,6 +1,9 @@
 # Environment for saving everything but the connections
 .lib_db_env <- new.env()
 
+DB_COORDINATION_MODE_NONE <- "none"
+DB_COORDINATION_MODE_TRANSFER <- "transfer"
+
 #' Initialize a module database context
 #'
 #' Loads the database connection settings for one module into the internal
@@ -209,6 +212,70 @@ dbSetContext <- function(module_name,
   .lib_db_env[["DB_ADMIN_USER"]] <- admin_user
   .lib_db_env[["DB_ADMIN_PASSWORD"]] <- admin_password
   .lib_db_env[["DB_ADMIN_SCHEMAS"]] <- admin_schemas
+  .lib_db_env[["DB_COORDINATION_MODE"]] <- NULL
+}
+
+#' Detect the Database Coordination Mode
+#'
+#' Transfer coordination is only used for writable databases that provide at
+#' least one of the INTERPOLAR transfer control functions. Read-only databases
+#' and databases without those functions do not need database locks for
+#' analyses.
+#'
+#' @return One of `none` or `transfer`.
+dbDetectCoordinationMode <- function() {
+  statement <- paste0(
+    "SELECT\n",
+    "  current_setting('transaction_read_only') = 'on' AS transaction_read_only,\n",
+    "  EXISTS (\n",
+    "    SELECT 1\n",
+    "    FROM pg_catalog.pg_proc AS p\n",
+    "    INNER JOIN pg_catalog.pg_namespace AS n ON n.oid = p.pronamespace\n",
+    "    WHERE n.nspname = 'db'\n",
+    "      AND p.proname IN (\n",
+    "        'data_transfer_status',\n",
+    "        'data_transfer_stop',\n",
+    "        'data_transfer_start',\n",
+    "        'data_transfer_reset_lock'\n",
+    "      )\n",
+    "  ) AS has_transfer_functions"
+  )
+  capabilities <- dbWithRetry(
+    db_call = function(db_connection) {
+      DBI::dbGetQuery(db_connection, statement)
+    },
+    call_label = "DBI::dbGetQuery",
+    sql = statement,
+    readonly = TRUE
+  )
+
+  if (isTRUE(capabilities[["transaction_read_only"]][1])) {
+    return(DB_COORDINATION_MODE_NONE)
+  }
+  if (isTRUE(capabilities[["has_transfer_functions"]][1])) {
+    return(DB_COORDINATION_MODE_TRANSFER)
+  }
+  DB_COORDINATION_MODE_NONE
+}
+
+#' Get the Cached Database Coordination Mode
+#'
+#' @return One of `none` or `transfer`.
+dbGetCoordinationMode <- function() {
+  coordination_mode <- .lib_db_env[["DB_COORDINATION_MODE"]]
+  if (is.null(coordination_mode)) {
+    coordination_mode <- dbDetectCoordinationMode()
+    .lib_db_env[["DB_COORDINATION_MODE"]] <- coordination_mode
+  }
+  coordination_mode
+}
+
+#' Check Whether Database Transfer Coordination Is Available
+#'
+#' @return `TRUE` for a database with active transfer coordination and `FALSE`
+#'   for an analysis database without it.
+dbUsesTransferCoordination <- function() {
+  identical(dbGetCoordinationMode(), DB_COORDINATION_MODE_TRANSFER)
 }
 
 #' Check if Database Logging is Enabled
@@ -559,7 +626,7 @@ dbCreateLockID <- function(...) {
 #'         of retries.
 #'
 dbLock <- function(lock_id) {
-  if (!is.null(lock_id)) {
+  if (!is.null(lock_id) && dbUsesTransferCoordination()) {
     full_lock_id <- dbCreateLockID(lock_id)
     # increase the recursive call counter 'db_lock_depth'
     db_lock_depth <- .lib_db_env[[lock_id]]
@@ -637,7 +704,7 @@ dbTransferDataInternal <- function() {
 #'
 dbUnlock <- function(lock_id, readonly = FALSE) {
   unlock_successful <- FALSE
-  if (!is.null(lock_id)) {
+  if (!is.null(lock_id) && dbUsesTransferCoordination()) {
     full_lock_id <- dbCreateLockID(lock_id)
     dbLog("Try to unlock database with lock_id: '", full_lock_id, "' and readonly: ", readonly)
     unlock_request <- paste0("SELECT db.data_transfer_start('", dbGetModuleName(), "', '", full_lock_id, "', ", readonly, ");")
@@ -692,6 +759,10 @@ dbUnlock <- function(lock_id, readonly = FALSE) {
 #'
 #' @export
 dbResetLock <- function() {
+  if (!dbUsesTransferCoordination()) {
+    dbLog("Database transfer lock is disabled for this database context")
+    return(FALSE)
+  }
   module_name <- dbGetModuleName()
   unlock_successful <- FALSE
   if (dbIsLockedByModule()) {

--- a/R-etlutils/etlutils/tests/testthat/test-lib_db.R
+++ b/R-etlutils/etlutils/tests/testthat/test-lib_db.R
@@ -130,3 +130,110 @@ test_that("dbCreateConnection closes connections after session setup errors", {
   )
   expect_true(disconnected)
 })
+
+test_that("dbGetCoordinationMode caches the detected mode per context", {
+  detection_count <- 0L
+  testthat::local_mocked_bindings(
+    dbDetectCoordinationMode = function() {
+      detection_count <<- detection_count + 1L
+      DB_COORDINATION_MODE_NONE
+    }
+  )
+
+  dbSetContext(
+    "dataprocessor", "snapshot", "host", 5432, "user", "password",
+    "schema_in", "schema_out", FALSE
+  )
+  expect_equal(dbGetCoordinationMode(), DB_COORDINATION_MODE_NONE)
+  expect_equal(dbGetCoordinationMode(), DB_COORDINATION_MODE_NONE)
+  expect_equal(detection_count, 1L)
+
+  dbSetContext(
+    "dataprocessor", "other_snapshot", "host", 5432, "user", "password",
+    "schema_in", "schema_out", FALSE
+  )
+  expect_equal(dbGetCoordinationMode(), DB_COORDINATION_MODE_NONE)
+  expect_equal(detection_count, 2L)
+})
+
+test_that("dbDetectCoordinationMode accepts read-only databases", {
+  testthat::local_mocked_bindings(
+    dbWithRetry = function(...) {
+      data.frame(
+        transaction_read_only = TRUE,
+        has_transfer_functions = TRUE
+      )
+    }
+  )
+
+  expect_equal(dbDetectCoordinationMode(), DB_COORDINATION_MODE_NONE)
+})
+
+test_that("dbDetectCoordinationMode accepts complete transfer coordination", {
+  detection_calls <- 0L
+  detection_sql <- NULL
+  testthat::local_mocked_bindings(
+    dbWithRetry = function(db_call,
+                           call_label,
+                           sql,
+                           readonly = FALSE,
+                           params = NULL,
+                           admin = FALSE) {
+      detection_calls <<- detection_calls + 1L
+      detection_sql <<- sql
+      expect_false(admin)
+      data.frame(
+        transaction_read_only = FALSE,
+        has_transfer_functions = TRUE
+      )
+    }
+  )
+
+  expect_equal(dbDetectCoordinationMode(), DB_COORDINATION_MODE_TRANSFER)
+  expect_equal(detection_calls, 1L)
+  expect_match(detection_sql, "EXISTS", fixed = TRUE)
+  expect_match(detection_sql, "'data_transfer_reset_lock'", fixed = TRUE)
+  expect_false(grepl("data_transfer_get_lock_module", detection_sql, fixed = TRUE))
+  expect_false(grepl("cron.job", detection_sql, fixed = TRUE))
+})
+
+test_that("dbDetectCoordinationMode accepts databases without transfer functions", {
+  testthat::local_mocked_bindings(
+    dbWithRetry = function(...) {
+      data.frame(
+        transaction_read_only = FALSE,
+        has_transfer_functions = FALSE
+      )
+    }
+  )
+
+  expect_equal(dbDetectCoordinationMode(), DB_COORDINATION_MODE_NONE)
+})
+
+test_that("database locks are no-ops without transfer coordination", {
+  testthat::local_mocked_bindings(
+    dbUsesTransferCoordination = function() FALSE,
+    dbGetStatus = function() fail("status must not be read"),
+    dbIsLockedByModule = function() fail("lock owner must not be read")
+  )
+
+  expect_null(dbLock("analysis"))
+  expect_false(dbUnlock("analysis"))
+  expect_false(dbResetLock())
+})
+
+test_that("read-only query results do not depend on transfer coordination", {
+  query_result <- data.table::data.table(patient_id = c(1L, 2L))
+  testthat::local_mocked_bindings(
+    dbUsesTransferCoordination = function() FALSE,
+    dbWithRetry = function(...) query_result
+  )
+
+  without_lock <- dbGetReadOnlyQuery("SELECT patient_id FROM v_patient")
+  with_inactive_lock <- dbGetReadOnlyQuery(
+    "SELECT patient_id FROM v_patient",
+    lock_id = "analysis"
+  )
+
+  expect_equal(with_inactive_lock, without_lock)
+})


### PR DESCRIPTION
## Zusammenfassung

- erkennt zentral in `etlutils`, ob die Datenbank schreibgeschützt ist und mindestens eine der vier typischen INTERPOLAR-Transfersteuerungsfunktionen bereitstellt
- verwendet diese Funktionen bewusst nur als Marker für die normale Cronjob-/Transferarchitektur
- führt Datenbank-Locks nur auf beschreibbaren Datenbanken mit einem solchen Marker aus; cron-freie Analyseabfragen bleiben unverändert
- benötigt für die Erkennung weder Adminzugang noch `pg_cron`-Metadaten
- übernimmt die Quell-`release_version` als minimale `v_db_parameter`-View in pseudonymisierte und Broad-Consent-Snapshots
- dokumentiert Voraussetzungen und Verhalten cron-freier Snapshot-Auswertungen

## Sicherheit und Abgrenzung

- schreibgeschützte Datenbanken verwenden unabhängig von enthaltenen Dump-Funktionen kein Transfer-Locking
- fehlt bei einer beschreibbaren Datenbank jeder der vier Funktionsmarker, wird das Locking vollständig übersprungen
- Statistical Reports und andere Auswertungsmodule wurden nicht verändert; sie profitieren zentral von `lib_db`
- `temp/` bleibt unberührt und unversioniert

## Tests

- vollständige `etlutils`-Testsuite
- vollständige Pseudonymisierungstestsuite mit lokal installiertem `etlutils`
- vollständige Tests für WP8-Export, Database Quality Analysis, MRP Check und Statistical Reports
- projektspezifischer Vollformatierer `Rscript tools/style-full.R`
- `git diff --check`

Ein zusätzlicher direkter `R CMD check` startet wegen der bereits auf `develop` fehlenden Felder `Author` und `Maintainer` in `R-etlutils/etlutils/DESCRIPTION` nicht; die Paket-Tests selbst sind vollständig grün.

Closes #1342