### PR TITLE
Run pseudonym mapping preparation before snapshot processing

### DIFF
--- a/Database_Snapshot.md
+++ b/Database_Snapshot.md
@@ -208,19 +208,28 @@ gleichnamige Snapshot-Datenbank.
 
 ## Ablauf bis zur Prüfung
 
-1. Die normale Snapshot-Datei wird in eine temporäre Quelldatenbank eingespielt.
+1. Wenn der Befehl `create --with-pseudonymized` oder
+   `create --with-broad-consent` verwendet wird, prüft das Script
+   `pseudo_mapping.xlsx` zuerst gegen die aktuell laufende
+   `cds_hub_db`. Dafür wird `StartSnapshotPseudonymization.R` ohne `target-db`
+   gestartet; in diesem Modus läuft nur die Vorprüfung. Fehlende Pseudonyme
+   müssen eingetragen werden, bevor der normale Snapshot erstellt wird.
+2. Die normale Snapshot-Datei wird in eine temporäre Quelldatenbank eingespielt.
    Das kann bei großen Snapshot-Dateien lange dauern.
-2. Das Script ergänzt und prüft `pseudo_mapping.xlsx`. Fehlende Pseudonyme
-   müssen vor der Fortsetzung eingetragen werden.
-3. Das Script erstellt eine temporäre Zieldatenbank und schreibt die
+3. `StartSnapshotPseudonymization.R` prüft `pseudo_mapping.xlsx` erneut gegen
+   die eingespielte Quelldatenbank. Weil der Aufruf hier zusätzlich eine
+   `target-db` enthält, startet nach erfolgreicher Prüfung die eigentliche
+   Pseudonymisierung. Damit bleiben zwischenzeitliche Änderungen oder
+   abweichende Snapshot-Inhalte sicher abgedeckt.
+4. Das Script erstellt eine temporäre Zieldatenbank und schreibt die
    pseudonymisierten Daten hinein.
-4. Die Zieldatenbank wird als neue Snapshot-Datei mit dem Suffix `_pseud`
+5. Die Zieldatenbank wird als neue Snapshot-Datei mit dem Suffix `_pseud`
    gespeichert.
-5. Die normale und die pseudonymisierte Snapshot-Datenbank werden in PostgreSQL
+6. Die normale und die pseudonymisierte Snapshot-Datenbank werden in PostgreSQL
    innerhalb des Docker-Compose-Service `cds_hub` schreibgeschützt unter ihren
    endgültigen Namen bereitgestellt. Ein zusätzliches `activate` ist nicht
    nötig.
-6. Mit `create --with-broad-consent` wird anschließend automatisch die
+7. Mit `create --with-broad-consent` wird anschließend automatisch die
    pseudonymisierte Snapshot-Datenbank verarbeitet. Alternativ kann dieser
    Schritt mit `create-broad-consent` einzeln ausgeführt werden. Derzeit bildet
    er nur den technischen Datenbank- und Dateilebenszyklus ab und filtert noch
@@ -384,10 +393,14 @@ Vor der Pseudonymisierung prüft das Script die Regeln, Spaltendefinitionen und
 Mapping-Voraussetzungen. Bei einem Problem bricht es mit einer Fehlermeldung
 ab.
 
-Nach dem Einspielen der Quelldatenbank ergänzt das Script fehlende Werte in
-`Input-Repo/pseudo_mapping.xlsx` und bricht ab. Nach dem manuellen Ausfüllen kann
-derselbe Befehl erneut gestartet werden; die bereits eingespielte Quelldatenbank
-wird wiederverwendet.
+Bei `create --with-pseudonymized` und `create --with-broad-consent` ergänzt das
+Script fehlende Werte in `Input-Repo/pseudo_mapping.xlsx` bereits vor dem
+normalen Snapshot und bricht ab. Nach dem manuellen Ausfüllen kann derselbe
+Befehl erneut gestartet werden. Direkt im R-Start der eigentlichen
+Pseudonymisierung wird dieselbe Prüfung gegen die konkrete
+Snapshot-Quelldatenbank wiederholt. Wenn dabei zusätzliche Werte gefunden
+werden, wird `pseudo_mapping.xlsx` erneut ergänzt und der Lauf bricht vor dem
+Schreiben der pseudonymisierten Daten ab.
 
 Bei späteren Fehlern bleibt die Quelldatenbank erhalten. Beim nächsten Lauf wird
 sie nur wiederverwendet, wenn ihr vermerkter SHA-256-Wert zur normalen

--- a/R-cdstoolchain/Snapshot_Pseudonymization_Cli.R
+++ b/R-cdstoolchain/Snapshot_Pseudonymization_Cli.R
@@ -1,0 +1,91 @@
+setSnapshotPseudonymizationWorkingDirectory <- function() {
+  if (grepl("/cdstoolchain$", getwd())) setwd("../..")
+  if (grepl("/R-cdstoolchain$", getwd())) setwd("../")
+}
+
+readSnapshotPseudonymizationArguments <- function(defaults) {
+  etlutils::initCommandLineArguments(
+    defaults = utils::modifyList(
+      list(
+        path_to_db_config_toml = "./cds_hub_db_config.toml",
+        path_to_dataprocessor_config_toml = "./R-dataprocessor/dataprocessor_config.toml",
+        project_root = ".",
+        source_schema = "db2dataprocessor_out",
+        review_report_file = NA_character_
+      ),
+      defaults
+    )
+  )
+}
+
+stopOnMissingSnapshotPseudonymizationArguments <- function(command_arguments, required_arguments, example) {
+  missing_arguments <- required_arguments[
+    !required_arguments %in% names(command_arguments) |
+      !nzchar(as.character(command_arguments[required_arguments]))
+  ]
+  if (length(missing_arguments) > 0) {
+    stop(
+      "Missing required argument(s): ",
+      paste(missing_arguments, collapse = ", "),
+      "\nExample: ", example
+    )
+  }
+}
+
+initSnapshotPseudonymizationModule <- function(
+  module_name,
+  command_arguments,
+  defaults = list(INPUT_REPO_PATH = "./Input-Repo"),
+  mandatory_parameters = c("INPUT_REPO_PATH", "PATH_TO_DB_CONFIG_TOML")
+) {
+  module_config <- etlutils::initModule(
+    module_name,
+    db_schema_base_name = "dataprocessor",
+    path_to_toml = command_arguments[["path_to_dataprocessor_config_toml"]],
+    defaults = utils::modifyList(
+      list(
+        VERBOSE = 10,
+        MAX_DIR_COUNT = 5,
+        PATH_TO_DB_CONFIG_TOML = command_arguments[["path_to_db_config_toml"]]
+      ),
+      defaults
+    ),
+    mandatory_parameters = mandatory_parameters
+  )
+  etlutils::startModule(module_config, hide_value_pattern = "TOKEN|PASSWORD|SALT")
+  module_config
+}
+
+readSnapshotPseudonymizationDbConfig <- function(command_arguments) {
+  etlutils::readTomlAsNamedList(command_arguments[["path_to_db_config_toml"]])
+}
+
+snapshotPseudonymizationConfigValue <- function(command_arguments, db_config, name, default = NULL) {
+  if (name %in% names(command_arguments) && nzchar(as.character(command_arguments[[name]]))) {
+    return(command_arguments[[name]])
+  }
+  config_name <- toupper(name)
+  if (config_name %in% names(db_config)) {
+    return(db_config[[config_name]])
+  }
+  default
+}
+
+connectSnapshotPseudonymizationDatabase <- function(
+  command_arguments,
+  db_config,
+  dbname,
+  user_argument,
+  password_argument
+) {
+  configValue <- function(name, default = NULL) {
+    snapshotPseudonymizationConfigValue(command_arguments, db_config, name, default)
+  }
+  etlutils::dbCreateConnection(
+    dbname = dbname,
+    host = configValue("db_host", "cds_hub"),
+    port = configValue("db_port", 5432),
+    user = configValue(user_argument, configValue("db_dataprocessor_user")),
+    password = configValue(password_argument, configValue("db_dataprocessor_password"))
+  )
+}

--- a/R-cdstoolchain/StartSnapshotPseudonymization.R
+++ b/R-cdstoolchain/StartSnapshotPseudonymization.R
@@ -3,89 +3,58 @@ library(etlutils)
 
 invisible(etlutils::setProcess("SnapshotPseudonymization"))
 
-# Change the working directory to the main project directory.
-if (grepl("/cdstoolchain$", getwd())) setwd("../..")
-if (grepl("/R-cdstoolchain$", getwd())) setwd("../")
+source_file <- if (file.exists("R-cdstoolchain/Snapshot_Pseudonymization_Cli.R")) {
+  "R-cdstoolchain/Snapshot_Pseudonymization_Cli.R"
+} else if (file.exists("../Snapshot_Pseudonymization_Cli.R")) {
+  "../Snapshot_Pseudonymization_Cli.R"
+} else {
+  "Snapshot_Pseudonymization_Cli.R"
+}
+source(source_file, local = TRUE)
 
-command_arguments <- etlutils::initCommandLineArguments(
+setSnapshotPseudonymizationWorkingDirectory()
+command_arguments <- readSnapshotPseudonymizationArguments(
   defaults = list(
-    path_to_db_config_toml = "./cds_hub_db_config.toml",
-    path_to_dataprocessor_config_toml = "./R-dataprocessor/dataprocessor_config.toml",
-    project_root = ".",
-    source_schema = "db2dataprocessor_out",
     target_table_schema = "db_log",
     target_view_schema = "db2dataprocessor_out",
-    chunk_size = NULL,
-    review_report_file = NA_character_
+    chunk_size = NULL
   )
 )
 
-required_arguments <- "source_db"
-missing_arguments <- required_arguments[
-  !required_arguments %in% names(command_arguments) |
-    !nzchar(as.character(command_arguments[required_arguments]))
-]
-if (length(missing_arguments) > 0) {
-  stop(
-    "Missing required argument(s): ",
-    paste(missing_arguments, collapse = ", "),
-    "\nExample: Rscript R-cdstoolchain/StartSnapshotPseudonymization.R ",
+stopOnMissingSnapshotPseudonymizationArguments(
+  command_arguments,
+  required_arguments = "source_db",
+  example = paste0(
+    "Rscript R-cdstoolchain/StartSnapshotPseudonymization.R ",
     "source-db=ip_snap01_20260716"
   )
-}
-mapping_preflight_only <- !(
+)
+run_preflight_only <- !(
   "target_db" %in% names(command_arguments) &&
     nzchar(as.character(command_arguments[["target_db"]]))
 )
 
-dataprocessor_config <- etlutils::initModule(
+dataprocessor_config <- initSnapshotPseudonymizationModule(
   "snapshot_pseudonymization",
-  db_schema_base_name = "dataprocessor",
-  path_to_toml = command_arguments[["path_to_dataprocessor_config_toml"]],
-  defaults = list(
-    VERBOSE = 10,
-    MAX_DIR_COUNT = 5,
-    PATH_TO_DB_CONFIG_TOML = command_arguments[["path_to_db_config_toml"]],
-    INPUT_REPO_PATH = "./Input-Repo"
-  ),
-  mandatory_parameters = c("INPUT_REPO_PATH", "PATH_TO_DB_CONFIG_TOML")
+  command_arguments
 )
-etlutils::startModule(dataprocessor_config, hide_value_pattern = "TOKEN|PASSWORD|SALT")
-
-db_config <- etlutils::readTomlAsNamedList(command_arguments[["path_to_db_config_toml"]])
-
-dbConfigValue <- function(name, default = NULL) {
-  if (name %in% names(command_arguments) && nzchar(as.character(command_arguments[[name]]))) {
-    return(command_arguments[[name]])
-  }
-  config_name <- toupper(name)
-  if (config_name %in% names(db_config)) {
-    return(db_config[[config_name]])
-  }
-  default
-}
-
-connectSnapshotDatabase <- function(dbname, user, password) {
-  etlutils::dbCreateConnection(
-    dbname = dbname,
-    host = dbConfigValue("db_host", "cds_hub"),
-    port = dbConfigValue("db_port", 5432),
-    user = user,
-    password = password
-  )
-}
+db_config <- readSnapshotPseudonymizationDbConfig(command_arguments)
 
 source_connection <- NULL
 target_connection <- NULL
 status <- 0L
 invisible(tryCatch(
   {
-    source_connection <- connectSnapshotDatabase(
+    source_connection <- connectSnapshotPseudonymizationDatabase(
+      command_arguments = command_arguments,
+      db_config = db_config,
       dbname = command_arguments[["source_db"]],
-      user = dbConfigValue("source_db_user", dbConfigValue("db_dataprocessor_user")),
-      password = dbConfigValue("source_db_password", dbConfigValue("db_dataprocessor_password"))
+      user_argument = "source_db_user",
+      password_argument = "source_db_password"
     )
-    if (mapping_preflight_only) {
+
+    if (run_preflight_only) {
+      message("\nNo target-db provided. Running snapshot pseudonymization preflight only.")
       pseudonym::preflightSnapshotPseudonymization(
         project_root = command_arguments[["project_root"]],
         input_repo_path = dataprocessor_config[["INPUT_REPO_PATH"]],
@@ -95,10 +64,12 @@ invisible(tryCatch(
         log_steps = TRUE
       )
     } else {
-      target_connection <- connectSnapshotDatabase(
+      target_connection <- connectSnapshotPseudonymizationDatabase(
+        command_arguments = command_arguments,
+        db_config = db_config,
         dbname = command_arguments[["target_db"]],
-        user = dbConfigValue("target_db_user", dbConfigValue("db_dataprocessor_user")),
-        password = dbConfigValue("target_db_password", dbConfigValue("db_dataprocessor_password"))
+        user_argument = "target_db_user",
+        password_argument = "target_db_password"
       )
 
       pseudonymization_result <- pseudonym::pseudonymizeSnapshotDatabase(
@@ -111,7 +82,6 @@ invisible(tryCatch(
         target_view_schema = command_arguments[["target_view_schema"]],
         chunk_size = command_arguments[["chunk_size"]],
         review_report_file = command_arguments[["review_report_file"]],
-        mapping_preflight_completed = TRUE,
         log_steps = TRUE
       )
       report_dir <- file.path(get("MODULE_DIRS", envir = .GlobalEnv)[["local_dir"]], "reports")

--- a/ip-snapshot.sh
+++ b/ip-snapshot.sh
@@ -217,6 +217,34 @@ container_input_repo_mount_args() {
     fi
 }
 
+check_live_database_pseudonym_mapping() {
+    local chunk_size="$1"
+
+    if [[ "${with_pseudonymized}" != "true" ]]; then
+        return
+    fi
+
+    local input_repo_mount_args=()
+    while IFS= read -r mount_arg; do
+        input_repo_mount_args+=("${mount_arg}")
+    done < <(container_input_repo_mount_args)
+
+    echo "Checking pseudonym mapping against the current database before creating the snapshot..."
+    if ! docker compose run --rm --no-deps "${input_repo_mount_args[@]}" r-env \
+        Rscript R-cdstoolchain/StartSnapshotPseudonymization.R \
+        source-db=cds_hub_db ; then
+        echo "Fix the pseudonym mapping and run the create command again."
+        echo "Continue afterwards with:"
+        if [[ "${with_broad_consent}" == "true" ]]; then
+            echo "  ./ip-snapshot.sh create ${name} --with-broad-consent --chunk-size ${chunk_size}"
+        else
+            echo "  ./ip-snapshot.sh create ${name} --with-pseudonymized --chunk-size ${chunk_size}"
+        fi
+        exit 1
+    fi
+    echo "Current database pseudonym mapping is complete."
+}
+
 database_exists() {
     local database_name="$1"
     docker compose exec -T cds_hub psql -U cds_hub_db_admin -d postgres -tAc \
@@ -449,20 +477,6 @@ create_pseudonymized_snapshot() {
             exit 1
         fi
     fi
-
-    echo "Checking database values and pseudonym mapping..."
-    if ! docker compose run --rm --no-deps "${input_repo_mount_args[@]}" r-env \
-        Rscript R-cdstoolchain/StartSnapshotPseudonymization.R \
-        source-db="${source_database}" ; then
-        cleanup_failed_pseudonymized_database "${target_build_db}"
-        echo "The fully restored source database remains available for continuing:"
-        echo "  ${source_database}"
-        echo
-        echo "Continue afterwards with:"
-        echo "  ./ip-snapshot.sh pseudonymize ${snapshot_name} --chunk-size ${chunk_size}"
-        exit 1
-    fi
-    echo "Database values and pseudonym mapping are complete."
 
     echo "Creating empty temporary target database '${target_build_db}'..."
     if ! prepare_snapshot_analysis_target_database "${target_build_db}" ; then
@@ -742,6 +756,7 @@ case "$action" in
 
         # Snapshot erstellen
         SECONDS=0;
+        check_live_database_pseudonym_mapping "${chunk_size}"
         if docker compose exec cds_hub pg_dump -U cds_hub_db_admin -d cds_hub_db --format=plain --exclude-extension=pg_cron --exclude-table=db_config.v_cron_jobs --exclude-table='*.*_raw*' --compress=gzip > $file_date_path; then
             echo "File \"${file_date_path}\" created."
             ls -ho ${file_date_path}


### PR DESCRIPTION
## Summary
- run the snapshot pseudonymization preflight before expensive snapshot creation when pseudonymized output is requested
- keep the same R entry point for preflight-only and full pseudonymization: without target-db it only checks, with target-db it pseudonymizes after checking
- document the updated snapshot pseudonymization flow

## Verification
- Rscript tools/style-full.R
- bash -n ip-snapshot.sh
- R parse check for StartSnapshotPseudonymization.R and Snapshot_Pseudonymization_Cli.R
- test-pseudonym-mapping-coverage.R
- test-pseudonymize-snapshot.R
- git diff --check

refs #1378