### PR TITLE
Require force for non-pseudonymized manual project databases

### DIFF
--- a/Database_Snapshot.md
+++ b/Database_Snapshot.md
@@ -290,14 +290,11 @@ lokale `database.toml` im jeweiligen Projektordner unter
 `database_example.toml` direkt in diesem Ordner. In jeder Projektdatei muss
 mindestens `DB_NAME` gesetzt sein. Die übrigen Werte werden aus der normalen
 DB-Konfiguration geerbt und nur durch nicht leere Projektwerte überschrieben.
-Die Auswahl erfolgt vor Lock- und Versionsprüfung. Die Originaldatenbank
-`cds_hub_db` ist für manuelle Projekte standardmäßig gesperrt und kann nur
-bewusst mit `--force` verwendet werden.
-
-Der Prozess prüft nicht, ob die Quelle pseudonymisiert ist. Er arbeitet mit den
-in der jeweiligen Datenbank vorhandenen Patienten- und Relationsschlüsseln.
-Dadurch kann derselbe Ablauf regulär auf der pseudonymisierten und bei Bedarf
-gesondert auf der nicht pseudonymisierten Snapshot-Datenbank ausgeführt werden.
+Die Auswahl erfolgt vor Lock- und Versionsprüfung. Ohne zusätzliches Argument
+starten manuelle Projekte nur auf pseudonymisierten Snapshot-Datenbanken, die in
+`v_db_parameter` als `database_content_type = pseudonymized_snapshot` markiert
+sind. Eine andere kompatible Datenbank, zum Beispiel ein normaler Snapshot oder
+die Originaldatenbank, kann nur bewusst mit `--force` verwendet werden.
 
 ### Inhalt der pseudonymisierten Snapshot-Datei und Snapshot-Datenbank
 

--- a/R-cdstoolchain/pseudonym/R/pseudonymize_snapshot_db.R
+++ b/R-cdstoolchain/pseudonym/R/pseudonymize_snapshot_db.R
@@ -91,7 +91,8 @@ getSnapshotReleaseVersion <- function(
 createSnapshotVersionView <- function(
   connection,
   release_version,
-  view_schema = "db2dataprocessor_out"
+  view_schema = "db2dataprocessor_out",
+  database_content_type = NULL
 ) {
   if (
     length(release_version) != 1L ||
@@ -110,6 +111,26 @@ createSnapshotVersionView <- function(
     ))
   }
   quoted_version <- as.character(DBI::dbQuoteString(connection, release_version))
+  content_type_statement <- ""
+  if (!is.null(database_content_type)) {
+    if (
+      length(database_content_type) != 1L ||
+      is.na(database_content_type) ||
+      !nzchar(database_content_type)
+    ) {
+      stop("database_content_type must be NULL or one non-empty value.", call. = FALSE)
+    }
+    quoted_content_type <- as.character(DBI::dbQuoteString(connection, database_content_type))
+    content_type_statement <- paste0(
+      " UNION ALL SELECT ",
+      "CAST(NULL AS integer) AS id, ",
+      "CAST('database_content_type' AS varchar) AS parameter_name, ",
+      "CAST(", quoted_content_type, " AS varchar) AS parameter_value, ",
+      "CAST('Database content type' AS varchar) AS parameter_description, ",
+      "CAST(NULL AS timestamp) AS input_datetime, ",
+      "CAST(NULL AS timestamp) AS last_change_timestamp"
+    )
+  }
   statement <- paste0(
     "CREATE VIEW ",
     snapshotQualifiedName(connection, view_name, view_schema),
@@ -119,7 +140,8 @@ createSnapshotVersionView <- function(
     "CAST(", quoted_version, " AS varchar) AS parameter_value, ",
     "CAST('Source database release version' AS varchar) AS parameter_description, ",
     "CAST(NULL AS timestamp) AS input_datetime, ",
-    "CAST(NULL AS timestamp) AS last_change_timestamp"
+    "CAST(NULL AS timestamp) AS last_change_timestamp",
+    content_type_statement
   )
   DBI::dbExecute(connection, statement)
   data.table::data.table(
@@ -617,7 +639,8 @@ pseudonymizeSnapshotDatabase <- function(
       version_summary <- createSnapshotVersionView(
         target_connection,
         release_version = result[["release_version"]],
-        view_schema = target_view_schema
+        view_schema = target_view_schema,
+        database_content_type = "pseudonymized_snapshot"
       )
       result[["view_summary"]] <- data.table::rbindlist(list(
         passthrough_summary,

--- a/R-cdstoolchain/pseudonym/tests/testthat/test-pseudonymize-snapshot-db.R
+++ b/R-cdstoolchain/pseudonym/tests/testthat/test-pseudonymize-snapshot-db.R
@@ -70,6 +70,26 @@ test_that("createSnapshotVersionView publishes the source release version", {
   expect_match(view_statement, "AS parameter_value", fixed = TRUE)
 })
 
+test_that("createSnapshotVersionView can mark pseudonymized snapshot databases", {
+  statements <- character()
+  testthat::local_mocked_bindings(
+    snapshotRelationExists = function(connection, name, schema = NULL) FALSE
+  )
+  testthat::local_mocked_bindings(
+    dbExecute = function(connection, statement) {
+      statements <<- c(statements, statement)
+      0L
+    },
+    .package = "DBI"
+  )
+
+  createSnapshotVersionView(DBI::ANSI(), "2.1.0", database_content_type = "pseudonymized_snapshot")
+
+  view_statement <- statements[grepl("CREATE VIEW", statements, fixed = TRUE)]
+  expect_match(view_statement, "CAST('database_content_type' AS varchar)", fixed = TRUE)
+  expect_match(view_statement, "CAST('pseudonymized_snapshot' AS varchar)", fixed = TRUE)
+})
+
 test_that("getSnapshotSourceViewPlan uses described table sources only", {
   rules <- data.table::data.table(
     SOURCE_TYPE = c("table_description", "snapshot_extension", "table_description"),

--- a/R-dataprocessor/README.md
+++ b/R-dataprocessor/README.md
@@ -23,10 +23,11 @@ Der Ordner der manuellen Projekte wird read-only in den R-Container
 eingebunden. Änderungen an `database.toml` erfordern deshalb keinen Neubau des
 R-Images.
 
-Die Datenbank wird vor Lock- und Versionsprüfung ausgewählt. Ein manuelles
-Projekt darf deshalb nicht versehentlich auf der Originaldatenbank
-`cds_hub_db` laufen. Ist das im Ausnahmefall ausdrücklich beabsichtigt, muss
-zusätzlich `--force` übergeben werden. Beispiel:
+Die Datenbank wird vor Lock- und Versionsprüfung ausgewählt. Ohne zusätzliches
+Argument starten manuelle Projekte nur auf pseudonymisierten Snapshot-Datenbanken,
+die in `v_db_parameter` als `database_content_type = pseudonymized_snapshot`
+markiert sind. Ist ein Lauf auf einer anderen kompatiblen Datenbank ausdrücklich
+beabsichtigt, muss zusätzlich `--force` übergeben werden. Beispiel:
 
 ```console
 docker compose run --rm --no-deps r-env Rscript R-dataprocessor/StartDataProcessor.R mrp-check --force

--- a/R-dataprocessor/dataprocessor/R/00_Manual_Project_Database.R
+++ b/R-dataprocessor/dataprocessor/R/00_Manual_Project_Database.R
@@ -250,6 +250,35 @@ validateManualStartDatabaseConnection <- function(db_config, project_name) {
   invisible(connection_details)
 }
 
+getManualStartDatabaseContentType <- function() {
+  content_type <- etlutils::dbGetReadOnlyQuery(
+    paste0(
+      "SELECT parameter_value ",
+      "FROM v_db_parameter ",
+      "WHERE parameter_name = 'database_content_type'"
+    ),
+    lock_id = NULL
+  )
+  if (!"parameter_value" %in% names(content_type)) {
+    stop(
+      "Could not validate selected database content type: ",
+      "v_db_parameter returned incomplete metadata.",
+      call. = FALSE
+    )
+  }
+  if (nrow(content_type) > 1L) {
+    stop(
+      "Could not validate selected database content type: ",
+      "v_db_parameter contains multiple database_content_type rows.",
+      call. = FALSE
+    )
+  }
+  if (!nrow(content_type)) {
+    return(NA_character_)
+  }
+  as.character(content_type$parameter_value[[1]])
+}
+
 setManualStartDatabaseContext <- function(db_config) {
   etlutils::dbSetModuleContext(
     module_name = "dataprocessor",
@@ -314,20 +343,21 @@ configureManualStartDatabase <- function(
     }
   )
   validateManualStartDatabaseConfig(db_config, project_name)
-  force_original_database <- "--force" %in% command_line_args
-  if (
-    identical(db_config[["DB_NAME"]], "cds_hub_db") &&
-    !force_original_database
-  ) {
-    stop(
-      "Manual Data Processor projects must not run on cds_hub_db by default. ",
-      "Use --force only when running this project on the original database is intentional.",
-      call. = FALSE
-    )
-  }
+  force_database <- "--force" %in% command_line_args
 
   setManualStartDatabaseContext(db_config)
   validateManualStartDatabaseConnection(db_config, project_name)
+  database_content_type <- getManualStartDatabaseContentType()
+  if (
+    !identical(database_content_type, "pseudonymized_snapshot") &&
+    !force_database
+  ) {
+    stop(
+      "Manual Data Processor projects must run on a pseudonymized snapshot database by default. ",
+      "Use --force only when running this project on another database is intentional.",
+      call. = FALSE
+    )
+  }
   message(
     "Manual Data Processor project '", project_name,
     "' database verified: ", db_config[["DB_NAME"]]

--- a/R-dataprocessor/dataprocessor/tests/testthat/test-manual-project-database.R
+++ b/R-dataprocessor/dataprocessor/tests/testthat/test-manual-project-database.R
@@ -135,6 +135,7 @@ test_that("manual projects inherit the normal connection and select DB_NAME", {
       expect_equal(db_config$DB_NAME, "ip_snapshot_pseud")
       expect_equal(project_name, "WP8_export")
     },
+    getManualStartDatabaseContentType = function() "pseudonymized_snapshot",
     .package = "dataprocessor"
   )
 
@@ -150,7 +151,7 @@ test_that("manual projects inherit the normal connection and select DB_NAME", {
   expect_equal(selected_config, result)
 })
 
-test_that("cds_hub_db requires an explicit force flag for manual projects", {
+test_that("non-pseudonymized databases require an explicit force flag for manual projects", {
   test_dir <- file.path(tempdir(), "manual-project-force")
   project_dir <- file.path(test_dir, "MRP_Check")
   dir.create(project_dir, recursive = TRUE, showWarnings = FALSE)
@@ -165,12 +166,12 @@ test_that("cds_hub_db requires an explicit force flag for manual projects", {
     "DB_DATAPROCESSOR_SCHEMA_OUT = \"db2dataprocessor_out\""
   ), base_config_path)
   writeLines(
-    "DB_NAME = \"cds_hub_db\"",
+    "DB_NAME = \"ip_snapshot\"",
     file.path(project_dir, "database.toml")
   )
   context_calls <- 0L
   effective_config <- list(
-    DB_NAME = "cds_hub_db",
+    DB_NAME = "ip_snapshot",
     DB_HOST = "cds_hub",
     DB_PORT = 5432,
     DB_DATAPROCESSOR_USER = "dataprocessor",
@@ -184,6 +185,7 @@ test_that("cds_hub_db requires an explicit force flag for manual projects", {
       context_calls <<- context_calls + 1L
     },
     validateManualStartDatabaseConnection = function(...) NULL,
+    getManualStartDatabaseContentType = function() NA_character_,
     .package = "dataprocessor"
   )
 
@@ -193,17 +195,17 @@ test_that("cds_hub_db requires an explicit force flag for manual projects", {
       command_line_args = "mrp-check",
       manual_start_submodule_dirs = project_dir
     ),
-    "must not run on cds_hub_db by default"
+    "must run on a pseudonymized snapshot database by default"
   )
-  expect_equal(context_calls, 0L)
+  expect_equal(context_calls, 1L)
 
   result <- configureManualStartDatabase(
     config = list(PATH_TO_DB_CONFIG_TOML = base_config_path),
     command_line_args = c("mrp-check", "--force"),
     manual_start_submodule_dirs = project_dir
   )
-  expect_equal(result$DB_NAME, "cds_hub_db")
-  expect_equal(context_calls, 1L)
+  expect_equal(result$DB_NAME, "ip_snapshot")
+  expect_equal(context_calls, 2L)
 })
 
 test_that("manual database configuration reports missing inherited values", {
@@ -299,6 +301,27 @@ test_that("manual database preflight validates the selected database", {
     validateManualStartDatabaseConnection(db_config, "WP8_export"),
     "cannot read required view.*Check the user's database permissions"
   )
+})
+
+test_that("manual database content type is read from v_db_parameter", {
+  content_type <- data.table::data.table(parameter_value = "pseudonymized_snapshot")
+  testthat::local_mocked_bindings(
+    dbGetReadOnlyQuery = function(query, lock_id) {
+      expect_match(query, "v_db_parameter", fixed = TRUE)
+      expect_match(query, "database_content_type", fixed = TRUE)
+      expect_null(lock_id)
+      content_type
+    },
+    .package = "etlutils"
+  )
+
+  expect_equal(getManualStartDatabaseContentType(), "pseudonymized_snapshot")
+
+  content_type <- data.table::data.table(parameter_value = character())
+  expect_true(is.na(getManualStartDatabaseContentType()))
+
+  content_type <- data.table::data.table(parameter_value = c("a", "b"))
+  expect_error(getManualStartDatabaseContentType(), "multiple database_content_type rows")
 })
 
 test_that("manual database connection errors include project and connection context", {

--- a/R-dataprocessor/submodules/manual_start/MRP_Check/README.md
+++ b/R-dataprocessor/submodules/manual_start/MRP_Check/README.md
@@ -31,8 +31,9 @@ Aufruf des dataprocessors mit folgenden Argumenten:
 docker compose run --rm --no-deps r-env Rscript R-dataprocessor/StartDataProcessor.R mrp-check
 ```
 
-Soll `MRP_Check` bewusst auf der Originaldatenbank `cds_hub_db` laufen, ist
-zusätzlich `--force` erforderlich.
+Ohne zusätzliches Argument startet `MRP_Check` nur auf einer pseudonymisierten
+Snapshot-Datenbank. Für jede andere kompatible Datenbank ist bewusst zusätzlich
+`--force` erforderlich.
 
 -   optional Anpassung des Zeitraumes über die Argumente `start-date` und `end-date` mit Name=Wert (ohne Leerzeichen zwischen Name und Wert) und Wert im Format YYYY-MM-DD
 

--- a/R-dataprocessor/submodules/manual_start/WP8_export/README.md
+++ b/R-dataprocessor/submodules/manual_start/WP8_export/README.md
@@ -85,8 +85,9 @@ Die lokale Datei wird automatisch read-only in den R-Container eingebunden;
 ein Neubau des Images ist nach einer Änderung nicht erforderlich.
 
 Der Data Processor wählt diese Datenbank vor Lock- und Versionsprüfung aus.
-`cds_hub_db` ist für manuelle Auswertungen standardmäßig gesperrt und kann nur
-bewusst mit dem zusätzlichen Argument `--force` verwendet werden.
+Ohne zusätzliches Argument startet das Projekt nur auf einer pseudonymisierten
+Snapshot-Datenbank. Für jede andere kompatible Datenbank ist bewusst zusätzlich
+`--force` erforderlich.
 
 ### Mapping-Arbeitsmappe
 


### PR DESCRIPTION
## Summary

- mark pseudonymized snapshot databases in `v_db_parameter`
- require that marker for manual Data Processor projects unless `--force` is passed
- update manual-project and snapshot documentation for the marker-based guard

## Tests

- `Rscript tools/style-full.R`
- `Rscript -e "Sys.setenv(NOT_CRAN='true'); pkgload::load_all('R-etlutils/etlutils', quiet=TRUE, export_all=FALSE); pkgload::load_all('R-dataprocessor/dataprocessor', quiet=TRUE); testthat::test_file('R-dataprocessor/dataprocessor/tests/testthat/test-manual-project-database.R')"`
- `Rscript -e "Sys.setenv(NOT_CRAN='true'); pkgload::load_all('R-cdstoolchain/pseudonym', quiet=TRUE); testthat::test_file('R-cdstoolchain/pseudonym/tests/testthat/test-pseudonymize-snapshot-db.R')"`
- `git diff --check`
