### PR TITLE
Fix conditional pseudonymization for Identifier type fields

### DIFF
--- a/R-cdstoolchain/pseudonym/R/pseudonymize_table.R
+++ b/R-cdstoolchain/pseudonym/R/pseudonymize_table.R
@@ -479,17 +479,42 @@ getConditionBaseExpression <- function(fhir_expression) {
   sub("[^/]+$", "", expression)
 }
 
-findConditionColumnName <- function(field_name, fhir_expression, table_description) {
-  field_expression <- gsub("\\.", "/", field_name)
-  condition_expression <- paste0(getConditionBaseExpression(fhir_expression), field_expression)
-  matches <- table_description[["COLUMN_NAME"]][
-    !is.na(table_description[["FHIR_EXPRESSION"]]) &
-      table_description[["FHIR_EXPRESSION"]] == condition_expression
-  ]
-  if (length(matches) == 0) {
+getIdentifierConditionExpression <- function(field_expression, fhir_expression) {
+  field_segments <- strsplit(field_expression, "/", fixed = TRUE)[[1]]
+  if (
+    !field_segments[1] %in% c("assigner", "period", "system", "type", "use", "value")
+  ) {
     return(NA_character_)
   }
-  matches[1]
+
+  expression_segments <- strsplit(as.character(fhir_expression), "/", fixed = TRUE)[[1]]
+  identifier_index <- which(expression_segments == "identifier")
+  if (length(identifier_index) == 0) {
+    return(NA_character_)
+  }
+
+  # Identifier conditions describe siblings below the enclosing Identifier node,
+  # even when the target column itself is nested below identifier/type/coding.
+  paste(c(expression_segments[seq_len(identifier_index[1])], field_segments), collapse = "/")
+}
+
+findConditionColumnName <- function(field_name, fhir_expression, table_description) {
+  field_expression <- gsub("\\.", "/", field_name)
+  condition_expressions <- unique(stats::na.omit(c(
+    getIdentifierConditionExpression(field_expression, fhir_expression),
+    paste0(getConditionBaseExpression(fhir_expression), field_expression)
+  )))
+
+  for (condition_expression in condition_expressions) {
+    matches <- table_description[["COLUMN_NAME"]][
+      !is.na(table_description[["FHIR_EXPRESSION"]]) &
+        table_description[["FHIR_EXPRESSION"]] == condition_expression
+    ]
+    if (length(matches) > 0) {
+      return(matches[1])
+    }
+  }
+  NA_character_
 }
 
 evaluateSingleCondition <- function(condition, table, table_description, fhir_expression) {

--- a/R-cdstoolchain/pseudonym/tests/testthat/test-pseudonymize-table.R
+++ b/R-cdstoolchain/pseudonym/tests/testthat/test-pseudonymize-table.R
@@ -171,6 +171,37 @@ test_that("conditional rules honor explicit keep and redact fallbacks", {
   expect_true(is.na(result$identifier_value[2]))
 })
 
+test_that("identifier type fields use the enclosing identifier for conditions", {
+  source_table <- data.table::data.table(
+    identifier_type_system = c("https://example.test", "https://example.test"),
+    identifier_type_code = c("MR", "OTHER"),
+    identifier_value = c("record-1", "record-2")
+  )
+  rule <- paste0(
+    "keepIf(type.coding.system == \"https://example.test\" & ",
+    "type.coding.code == \"MR\"); redact"
+  )
+  table_description <- data.table::data.table(
+    RESOURCE = c("Patient", NA, NA),
+    COLUMN_NAME = names(source_table),
+    FHIR_EXPRESSION = c(
+      "identifier/type/coding/system",
+      "identifier/type/coding/code",
+      "identifier/value"
+    ),
+    PSEUDONYMIZATION_RULE = rule
+  )
+
+  result <- pseudonymizeTable(source_table, table_description, "Patient")
+
+  expect_equal(result$identifier_type_system[1], source_table$identifier_type_system[1])
+  expect_equal(result$identifier_type_code[1], source_table$identifier_type_code[1])
+  expect_equal(result$identifier_value[1], source_table$identifier_value[1])
+  expect_true(is.na(result$identifier_type_system[2]))
+  expect_true(is.na(result$identifier_type_code[2]))
+  expect_true(is.na(result$identifier_value[2]))
+})
+
 test_that("conditional rules treat NA conditions as not matched", {
   source_table <- data.table::data.table(
     identifier_type_system = NA_character_,
@@ -366,6 +397,14 @@ test_that("default rules retain approved logical reference identifiers", {
   result <- pseudonymizeTable(source_table, table_description, "Encounter")
 
   expect_equal(
+    result$enc_subject_identifier_type_coding_system[1:2],
+    source_table$enc_subject_identifier_type_coding_system[1:2]
+  )
+  expect_equal(
+    result$enc_subject_identifier_type_coding_code[1:2],
+    source_table$enc_subject_identifier_type_coding_code[1:2]
+  )
+  expect_equal(
     result$enc_subject_identifier_system[1:4],
     source_table$enc_subject_identifier_system[1:4]
   )
@@ -379,6 +418,8 @@ test_that("default rules retain approved logical reference identifiers", {
     source_table$enc_subject_identifier_value[3:4]
   )
   expect_true(is.na(result$enc_subject_identifier_system[5]))
+  expect_true(is.na(result$enc_subject_identifier_type_coding_system[5]))
+  expect_true(is.na(result$enc_subject_identifier_type_coding_code[5]))
   expect_true(is.na(result$enc_subject_identifier_value[5]))
 })
 


### PR DESCRIPTION
## Summary

- resolve Identifier rule conditions from the enclosing `Identifier` node before falling back to the old relative target-column lookup
- keep allowed `identifier/type/coding/system` and `identifier/type/coding/code` values for MR/VN-style Identifier rules
- add regression coverage for direct Identifier columns and Reference-Identifier columns

## Tests

- `Rscript tools/style-full.R`
- `Rscript -e "Sys.setenv(NOT_CRAN='true'); pkgload::load_all('R-etlutils/etlutils', quiet=TRUE); pkgload::load_all('R-cdstoolchain/pseudonym', quiet=TRUE); testthat::test_file('R-cdstoolchain/pseudonym/tests/testthat/test-pseudonymize-table.R')"`
- `Rscript -e "Sys.setenv(NOT_CRAN='true'); pkgload::load_all('R-etlutils/etlutils', quiet=TRUE); pkgload::load_all('R-cdstoolchain/pseudonym', quiet=TRUE); testthat::test_file('R-cdstoolchain/pseudonym/tests/testthat/test-pseudonymization-table-description.R')"`
- `git diff --check`
