### PR TITLE
Calculate medication analysis BMI in pseudonymized snapshots

### DIFF
--- a/Database_Snapshot.md
+++ b/Database_Snapshot.md
@@ -432,6 +432,9 @@ der pseudonymisierten Snapshot-Datenbank:
   `enc_age_at_admission`.
 - `fall_bmi` wird befüllt, wenn Gewicht und Größe in unterstützten Einheiten
   vorliegen. Unterstützt werden `kg`, `g`, `mg`, `m`, `cm` und `mm`.
+- `medikationsanalyse_fe` erhält analog `meda_bmi` aus
+  `meda_gewicht_aktuell` und `meda_groesse`, wenn beide Werte in unterstützten
+  Einheiten vorliegen.
 - `observation_old_versions` und `observation_last_version` erhalten
   `analysis_loinc_code`, `analysis_unit`, `analysis_value` und
   `analysis_value_status`. Wenn die

--- a/R-cdstoolchain/pseudonym/R/enrich_case_metrics.R
+++ b/R-cdstoolchain/pseudonym/R/enrich_case_metrics.R
@@ -206,6 +206,40 @@ calculateBmi <- function(weight_values, weight_units, height_values, height_unit
   result
 }
 
+enrichSnapshotBmiColumn <- function(
+  table,
+  target_column,
+  weight_column,
+  weight_unit_column,
+  height_column,
+  height_unit_column,
+  enrichment_columns,
+  source_columns
+) {
+  if (!target_column %in% enrichment_columns) {
+    return(table)
+  }
+  if (!target_column %in% names(table)) {
+    table[[target_column]] <- rep(NA_real_, nrow(table))
+  }
+
+  bmi_columns <- c(
+    weight_column,
+    weight_unit_column,
+    height_column,
+    height_unit_column
+  )
+  if (all(bmi_columns %in% source_columns) && all(bmi_columns %in% names(table))) {
+    table[[target_column]] <- calculateBmi(
+      table[[weight_column]],
+      table[[weight_unit_column]],
+      table[[height_column]],
+      table[[height_unit_column]]
+    )
+  }
+  table
+}
+
 enrichSnapshotFallChunk <- function(
   fall_fe,
   birthdates = NULL,
@@ -219,10 +253,6 @@ enrichSnapshotFallChunk <- function(
   ) {
     fall_fe[["fall_age_at_admission"]] <- rep(NA_integer_, nrow(fall_fe))
   }
-  if ("fall_bmi" %in% enrichment_columns && !"fall_bmi" %in% names(fall_fe)) {
-    fall_fe[["fall_bmi"]] <- rep(NA_real_, nrow(fall_fe))
-  }
-
   if (
     "fall_age_at_admission" %in% enrichment_columns &&
     "fall_aufn_dat" %in% source_columns &&
@@ -235,26 +265,16 @@ enrichSnapshotFallChunk <- function(
     )
   }
 
-  bmi_columns <- c(
-    "fall_gewicht_aktuell",
-    "fall_gewicht_aktl_einheit",
-    "fall_groesse",
-    "fall_groesse_einheit"
+  enrichSnapshotBmiColumn(
+    fall_fe,
+    target_column = "fall_bmi",
+    weight_column = "fall_gewicht_aktuell",
+    weight_unit_column = "fall_gewicht_aktl_einheit",
+    height_column = "fall_groesse",
+    height_unit_column = "fall_groesse_einheit",
+    enrichment_columns = enrichment_columns,
+    source_columns = source_columns
   )
-  if (
-    "fall_bmi" %in% enrichment_columns &&
-    all(bmi_columns %in% source_columns) &&
-    all(bmi_columns %in% names(fall_fe))
-  ) {
-    fall_fe[["fall_bmi"]] <- calculateBmi(
-      fall_fe[["fall_gewicht_aktuell"]],
-      fall_fe[["fall_gewicht_aktl_einheit"]],
-      fall_fe[["fall_groesse"]],
-      fall_fe[["fall_groesse_einheit"]]
-    )
-  }
-
-  fall_fe
 }
 
 enrichSnapshotEncounterChunk <- function(
@@ -282,6 +302,25 @@ enrichSnapshotEncounterChunk <- function(
     )
   }
   encounter
+}
+
+enrichSnapshotMedicationAnalysisChunk <- function(
+  medikationsanalyse_fe,
+  birthdates = NULL,
+  enrichment_columns = getSnapshotCaseEnrichmentSpec("medikationsanalyse_fe")[["enrichment_columns"]],
+  source_columns = names(medikationsanalyse_fe)
+) {
+  medikationsanalyse_fe <- data.table::as.data.table(data.table::copy(medikationsanalyse_fe))
+  enrichSnapshotBmiColumn(
+    medikationsanalyse_fe,
+    target_column = "meda_bmi",
+    weight_column = "meda_gewicht_aktuell",
+    weight_unit_column = "meda_gewicht_aktl_einheit",
+    height_column = "meda_groesse",
+    height_unit_column = "meda_groesse_einheit",
+    enrichment_columns = enrichment_columns,
+    source_columns = source_columns
+  )
 }
 
 # Case enrichment cannot be derived from column naming alone. Keep its schema
@@ -315,5 +354,10 @@ SNAPSHOT_CASE_ENRICHMENT_SPECS <- list(
     review_patient_column = "enc_patient_ref",
     review_patient_reference_type = "Patient",
     review_encounter_column = "enc_id"
+  ),
+  medikationsanalyse_fe = list(
+    enrichment_function = enrichSnapshotMedicationAnalysisChunk,
+    enrichment_columns = "meda_bmi",
+    age_column = NULL
   )
 )

--- a/R-cdstoolchain/pseudonym/R/pseudonymize_snapshot_streaming.R
+++ b/R-cdstoolchain/pseudonym/R/pseudonymize_snapshot_streaming.R
@@ -717,6 +717,7 @@ getSnapshotStreamingSourceQuery <- function(
   case_spec <- getSnapshotCaseEnrichmentSpec(base_table_name)
   if (
     !is.null(case_spec) &&
+    !is.null(case_spec[["age_column"]]) &&
     case_spec[["age_column"]] %in% described_columns
   ) {
     patient_relation_name <- paste0(
@@ -1099,7 +1100,8 @@ streamSnapshotMaterializedTable <- function(
           query_info[["medication_spec"]]
         )
       }
-      age_review <- if (!is.null(getSnapshotCaseEnrichmentSpec(base_table_name))) {
+      case_spec <- getSnapshotCaseEnrichmentSpec(base_table_name)
+      age_review <- if (!is.null(case_spec) && !is.null(case_spec[["age_column"]])) {
         birthdates <- if (SNAPSHOT_STREAMING_BIRTHDATE_COLUMN %in% names(chunk)) {
           chunk[[SNAPSHOT_STREAMING_BIRTHDATE_COLUMN]]
         } else {

--- a/R-cdstoolchain/pseudonym/tests/testthat/test-enrich-case-metrics.R
+++ b/R-cdstoolchain/pseudonym/tests/testthat/test-enrich-case-metrics.R
@@ -33,6 +33,21 @@ test_that("enrichSnapshotEncounterChunk adds age", {
   expect_equal(tail(names(result), 1), "enc_age_at_admission")
 })
 
+test_that("enrichSnapshotMedicationAnalysisChunk calculates BMI", {
+  medication_analysis <- data.table::data.table(
+    meda_gewicht_aktuell = c(80, 75000, NA),
+    meda_gewicht_aktl_einheit = c("kg", "g", "kg"),
+    meda_groesse = c(180, 1.5, 170),
+    meda_groesse_einheit = c("cm", "m", "cm"),
+    meda_bmi = c(999, 999, 999)
+  )
+
+  result <- enrichSnapshotMedicationAnalysisChunk(medication_analysis)
+
+  expect_equal(result$meda_bmi[1:2], c(80 / 1.8^2, 75 / 1.5^2))
+  expect_true(is.na(result$meda_bmi[3]))
+})
+
 test_that("case metric enrichment remains optional when source columns are missing", {
   fall_result <- enrichSnapshotFallChunk(
     data.table::data.table(fall_id = "fall-1"),
@@ -42,10 +57,15 @@ test_that("case metric enrichment remains optional when source columns are missi
     data.table::data.table(enc_id = "enc-1"),
     source_columns = "enc_id"
   )
+  medication_analysis_result <- enrichSnapshotMedicationAnalysisChunk(
+    data.table::data.table(meda_gewicht_aktuell = 80),
+    source_columns = "meda_gewicht_aktuell"
+  )
 
   expect_true(is.na(fall_result$fall_age_at_admission))
   expect_true(is.na(fall_result$fall_bmi))
   expect_true(is.na(encounter_result$enc_age_at_admission))
+  expect_true(is.na(medication_analysis_result$meda_bmi))
 })
 
 test_that("age calculation accepts 1910-01-01 and rejects earlier birthdates", {

--- a/R-cdstoolchain/pseudonym/tests/testthat/test-pseudonymize-snapshot-streaming.R
+++ b/R-cdstoolchain/pseudonym/tests/testthat/test-pseudonymize-snapshot-streaming.R
@@ -479,6 +479,26 @@ test_that("streaming case enrichment keeps lookup columns until review", {
   expect_equal(result[[SNAPSHOT_STREAMING_PATIENT_KEY_COLUMN]], "patient-1")
 })
 
+test_that("streaming enrichment calculates medication analysis BMI", {
+  context <- newSnapshotStreamingContext(NULL)
+  medication_analysis <- data.table::data.table(
+    meda_gewicht_aktuell = 80,
+    meda_gewicht_aktl_einheit = "kg",
+    meda_groesse = 2,
+    meda_groesse_einheit = "m",
+    meda_bmi = NA_real_
+  )
+
+  result <- enrichSnapshotStreamingChunk(
+    medication_analysis,
+    "medikationsanalyse_fe",
+    context,
+    described_columns = names(medication_analysis)
+  )
+
+  expect_equal(result$meda_bmi, 20)
+})
+
 test_that("streaming enrichment only creates columns described by table description", {
   context <- newSnapshotStreamingContext(NULL)
   fall <- data.table::data.table(
@@ -542,6 +562,7 @@ test_that("snapshot enrichments preserve typed columns for empty partitions", {
   enriched_observation <- enrichObservationWithLoincMapping(observation, mapping)
   enriched_fall <- enrichSnapshotFallChunk(data.table::data.table())
   enriched_encounter <- enrichSnapshotEncounterChunk(data.table::data.table())
+  enriched_medication_analysis <- enrichSnapshotMedicationAnalysisChunk(data.table::data.table())
   enriched_medication <- enrichSnapshotStreamingChunk(
     data.table::data.table(),
     "medicationrequest",
@@ -557,6 +578,7 @@ test_that("snapshot enrichments preserve typed columns for empty partitions", {
   expect_type(enriched_fall$fall_age_at_admission, "integer")
   expect_type(enriched_fall$fall_bmi, "double")
   expect_type(enriched_encounter$enc_age_at_admission, "integer")
+  expect_type(enriched_medication_analysis$meda_bmi, "double")
   expect_true(all(vapply(enriched_medication, is.character, logical(1))))
 })
 


### PR DESCRIPTION
## Zusammenfassung

- berechnet `meda_bmi` während der Snapshot-Pseudonymisierung aus `meda_gewicht_aktuell` und `meda_groesse`
- verwendet dieselbe bestehende Einheitenkonvertierung und Validierung wie `fall_bmi`
- überschreibt einen vorhandenen BMI mit dem aus den aktuellen Gewichts- und Größenwerten berechneten Wert
- lässt `meda_bmi` leer, wenn Werte oder unterstützte Einheiten fehlen
- dokumentiert die zusätzliche Snapshot-Anreicherung

Refs #1264

## Tests

- `Rscript tools/style-full.R`
- vollständige Testsuite von `R-cdstoolchain/pseudonym`: 480 bestanden, 0 fehlgeschlagen, 0 Warnungen