### PR TITLE
Preserve database content type in Broad Consent snapshots

### DIFF
--- a/Database_Snapshot.md
+++ b/Database_Snapshot.md
@@ -280,6 +280,13 @@ Versionsprüfung benötigte View `db2dataprocessor_out.v_db_parameter`. Sie stel
 die `release_version` der jeweiligen Quelldatenbank bereit, ohne die übrige
 Datenbankkonfiguration in den Snapshot zu kopieren.
 
+Bei der Erzeugung eines Broad-Consent-Snapshots wird außerdem ein vorhandener
+`database_content_type` unverändert aus der Quelldatenbank übernommen. Fehlt
+dieser Marker in der Quelle, wird für das Ziel kein Inhaltstyp angenommen oder
+aus dem Datenbanknamen abgeleitet. Ein aus einem markierten pseudonymisierten
+Snapshot erzeugter Broad-Consent-Snapshot kann deshalb ohne `--force` für
+manuelle Data-Processor-Projekte verwendet werden.
+
 Die gemeinsame Datenbankbibliothek prüft beim ersten Zugriff, ob die ausgewählte
 Datenbank schreibgeschützt ist und ob mindestens eine der für die
 INTERPOLAR-Transfersteuerung typischen Datenbankfunktionen vorhanden ist. Nur

--- a/R-cdstoolchain/pseudonym/R/broad_consent_snapshot.R
+++ b/R-cdstoolchain/pseudonym/R/broad_consent_snapshot.R
@@ -247,9 +247,13 @@ createBroadConsentSnapshotDatabase <- function(
 
   result <- list()
   runPseudonymizationLogStep(2L,
-    "Read source database release version",
+    "Read source database metadata",
     {
       result[["release_version"]] <- getSnapshotReleaseVersion(
+        source_connection,
+        source_schema = source_schema
+      )
+      result[["database_content_type"]] <- getSnapshotDatabaseContentType(
         source_connection,
         source_schema = source_schema
       )
@@ -325,7 +329,8 @@ createBroadConsentSnapshotDatabase <- function(
       version_summary <- createSnapshotVersionView(
         target_connection,
         release_version = result[["release_version"]],
-        view_schema = target_view_schema
+        view_schema = target_view_schema,
+        database_content_type = result[["database_content_type"]]
       )
       result[["view_summary"]] <- data.table::rbindlist(list(
         passthrough_summary,

--- a/R-cdstoolchain/pseudonym/R/pseudonymize_snapshot_db.R
+++ b/R-cdstoolchain/pseudonym/R/pseudonymize_snapshot_db.R
@@ -88,6 +88,34 @@ getSnapshotReleaseVersion <- function(
   release_version
 }
 
+getSnapshotDatabaseContentType <- function(
+  connection,
+  source_schema = "db2dataprocessor_out"
+) {
+  source_view <- snapshotQualifiedName(connection, "v_db_parameter", source_schema)
+  statement <- paste0(
+    "SELECT parameter_value FROM ",
+    source_view,
+    " WHERE parameter_name = 'database_content_type'"
+  )
+  content_type_rows <- DBI::dbGetQuery(connection, statement)
+  if (nrow(content_type_rows) > 1L) {
+    stop(
+      "Source view ", source_view,
+      " must contain at most one database_content_type row.",
+      call. = FALSE
+    )
+  }
+  if (!nrow(content_type_rows)) {
+    return(NULL)
+  }
+  database_content_type <- as.character(content_type_rows[["parameter_value"]][1])
+  if (is.na(database_content_type) || !nzchar(database_content_type)) {
+    stop("Source database_content_type must not be empty.", call. = FALSE)
+  }
+  database_content_type
+}
+
 createSnapshotVersionView <- function(
   connection,
   release_version,

--- a/R-cdstoolchain/pseudonym/tests/testthat/test-broad-consent-snapshot.R
+++ b/R-cdstoolchain/pseudonym/tests/testthat/test-broad-consent-snapshot.R
@@ -141,6 +141,10 @@ test_that("Broad Consent database workflow materializes and publishes its plan",
       captured$version_connection <- connection
       "2.1.0"
     },
+    getSnapshotDatabaseContentType = function(connection, source_schema) {
+      captured$content_type_connection <- connection
+      "pseudonymized_snapshot"
+    },
     getDefaultSnapshotPseudonymizationRuleSources = function(project_root) {
       list(table_descriptions = "rules", snapshot_extensions = "extensions")
     },
@@ -197,9 +201,15 @@ test_that("Broad Consent database workflow materializes and publishes its plan",
       captured$view_connection <- connection
       view_summary
     },
-    createSnapshotVersionView = function(connection, release_version, view_schema) {
+    createSnapshotVersionView = function(
+                                         connection,
+                                         release_version,
+                                         view_schema,
+                                         database_content_type
+    ) {
       captured$version_view_connection <- connection
       captured$release_version <- release_version
+      captured$database_content_type <- database_content_type
       version_summary
     }
   )
@@ -217,6 +227,7 @@ test_that("Broad Consent database workflow materializes and publishes its plan",
 
   expect_equal(captured$plan_connection, "source-connection")
   expect_equal(captured$version_connection, "source-connection")
+  expect_equal(captured$content_type_connection, "source-connection")
   expect_equal(captured$target_schema, "db_log")
   expect_equal(captured$temporary_source_connection, "source-connection")
   expect_equal(captured$stream_connections, c("source-connection", "target-connection"))
@@ -225,9 +236,11 @@ test_that("Broad Consent database workflow materializes and publishes its plan",
   expect_equal(captured$view_connection, "target-connection")
   expect_equal(captured$version_view_connection, "target-connection")
   expect_equal(captured$release_version, "2.1.0")
+  expect_equal(captured$database_content_type, "pseudonymized_snapshot")
   expect_equal(result$materialization_plan, plan)
   expect_equal(result$summary, summary)
   expect_equal(result$release_version, "2.1.0")
+  expect_equal(result$database_content_type, "pseudonymized_snapshot")
   expect_equal(
     result$view_summary,
     data.table::rbindlist(list(view_summary, version_summary))

--- a/R-cdstoolchain/pseudonym/tests/testthat/test-pseudonymize-snapshot-db.R
+++ b/R-cdstoolchain/pseudonym/tests/testthat/test-pseudonymize-snapshot-db.R
@@ -48,6 +48,44 @@ test_that("getSnapshotReleaseVersion rejects missing or empty versions", {
   expect_error(getSnapshotReleaseVersion(DBI::ANSI()), "must not be empty")
 })
 
+test_that("getSnapshotDatabaseContentType preserves an optional source marker", {
+  content_type_rows <- data.frame(parameter_value = "pseudonymized_snapshot")
+  captured_statement <- NULL
+  testthat::local_mocked_bindings(
+    dbGetQuery = function(connection, statement) {
+      captured_statement <<- statement
+      content_type_rows
+    },
+    .package = "DBI"
+  )
+
+  expect_equal(
+    getSnapshotDatabaseContentType(DBI::ANSI(), "db2dataprocessor_out"),
+    "pseudonymized_snapshot"
+  )
+  expect_match(
+    captured_statement,
+    'FROM "db2dataprocessor_out"."v_db_parameter"',
+    fixed = TRUE
+  )
+
+  content_type_rows <- data.frame(parameter_value = character())
+  expect_null(getSnapshotDatabaseContentType(DBI::ANSI()))
+})
+
+test_that("getSnapshotDatabaseContentType rejects invalid source markers", {
+  content_type_rows <- data.frame(parameter_value = c("first", "second"))
+  testthat::local_mocked_bindings(
+    dbGetQuery = function(connection, statement) content_type_rows,
+    .package = "DBI"
+  )
+
+  expect_error(getSnapshotDatabaseContentType(DBI::ANSI()), "at most one")
+
+  content_type_rows <- data.frame(parameter_value = "")
+  expect_error(getSnapshotDatabaseContentType(DBI::ANSI()), "must not be empty")
+})
+
 test_that("createSnapshotVersionView publishes the source release version", {
   statements <- character()
   testthat::local_mocked_bindings(


### PR DESCRIPTION
## Änderung

- liest `database_content_type` aus `v_db_parameter` der Broad-Consent-Quelldatenbank
- übernimmt einen vorhandenen Marker unverändert in die Ziel-View
- lässt das Ziel bei markerlosen Altquellen weiterhin unmarkiert
- lehnt doppelte oder leere Quellenmarker als inkonsistente Metadaten ab
- dokumentiert, dass markierte pseudonymisierte Quellen ohne `--force` für manuelle Projekte nutzbare Broad-Consent-Snapshots erzeugen

Closes #1405

## Tests

- `Rscript tools/style-full.R`
- fokussierte Tests für `test-pseudonymize-snapshot-db.R` und `test-broad-consent-snapshot.R`
- vollständiger `R-cdstoolchain/pseudonym/tests/testthat`-Lauf mit aktuellem lokalem `etlutils`: erfolgreich
- Docker-End-to-End-Lauf aus `ip_release_210_test_20260902_pseud_pr1404_bmi` nach `ip_bc_pr1405_test_20260903`
- Zielmarker geprüft: `database_content_type = pseudonymized_snapshot`, `release_version = 2.0.0`
- Ziel schreibgeschützt gesetzt
- `MRP_Check` gegen die neue Broad-Consent-Datenbank ohne `--force`: vollständig erfolgreich