### PR TITLE
Add concise package READMEs for pseudonym and cdstoolchain

### DIFF
--- a/R-cdstoolchain/cdstoolchain/README.md
+++ b/R-cdstoolchain/cdstoolchain/README.md
@@ -1,0 +1,31 @@
+# cdstoolchain
+
+`cdstoolchain` ist die Orchestrierungsschicht der INTERPOLAR-R-Module. Sie koordiniert deren
+Initialisierung und Ausführungsreihenfolge, implementiert aber weder FHIR-Import noch fachliche
+Datenverarbeitung, Datenbank-/Frontend-Synchronisation oder Pseudonymisierung selbst. Diese Logik
+bleibt in `cds2db`, `dataprocessor`, `db2frontend`, `etlutils` und `pseudonym`.
+
+## Öffentliche Einstiege
+
+Das Paket exportiert derzeit keine R-Funktionen; seine [`NAMESPACE`](NAMESPACE) ist leer. Die
+tatsächlichen Einstiege liegen als Skripte im übergeordneten Verzeichnis:
+
+- [`StartCDSToolChainWithVacuum.sh`](../../StartCDSToolChainWithVacuum.sh) ist der dokumentierte
+  Einstieg für den vollständigen regulären Lauf einschließlich `VACUUM (ANALYZE)`.
+- [`StartCDSToolChain.R`](../StartCDSToolChain.R) führt die reguläre Modulkette aus.
+- [`StartDataImport.R`](../StartDataImport.R) steuert vollständige oder ressourcenbezogene Importe.
+- [`StartMRPRecalculation.R`](../StartMRPRecalculation.R) startet die additive MRP-Neuberechnung.
+- Die Snapshot-Skripte verwenden das separate [`pseudonym`](../pseudonym/README.md)-Paket.
+
+Die projektweite Verwendung erläutert die [zentrale README](../../README.md). Details zur
+Einrichtung und zum Betrieb stehen in [`Install.md`](../../Install.md) und
+[`Operation.md`](../../Operation.md); die MRP-Neuberechnung ist in
+[`README_MRP_Recalculation.md`](../README_MRP_Recalculation.md) beschrieben.
+
+## Tests und Modulschnittstellen
+
+Der `testthat`-Einstieg liegt unter [`tests/testthat`](tests/testthat); der aktuelle Pakettest ist
+noch ein Gerüsttest. Das Verhalten der delegierten Schritte wird in den jeweiligen Modulpaketen
+getestet und dokumentiert: [`cds2db`](../../R-cds2db/cds2db/README.md),
+[`dataprocessor`](../../R-dataprocessor/dataprocessor/README.md),
+[`db2frontend`](../../R-db2frontend/README.md) und [`etlutils`](../../R-etlutils/etlutils/README.md).

--- a/R-cdstoolchain/cdstoolchain/README.md
+++ b/R-cdstoolchain/cdstoolchain/README.md
@@ -1,31 +1,24 @@
 # cdstoolchain
 
-`cdstoolchain` ist die Orchestrierungsschicht der INTERPOLAR-R-Module. Sie koordiniert deren
-Initialisierung und Ausführungsreihenfolge, implementiert aber weder FHIR-Import noch fachliche
-Datenverarbeitung, Datenbank-/Frontend-Synchronisation oder Pseudonymisierung selbst. Diese Logik
-bleibt in `cds2db`, `dataprocessor`, `db2frontend`, `etlutils` und `pseudonym`.
+Der Bereich `R-cdstoolchain` verbindet die INTERPOLAR-R-Module zu ausführbaren Abläufen. Die
+eigentliche Fachlogik bleibt in `cds2db`, `dataprocessor`, `db2frontend`, `etlutils` und
+`pseudonym`; hier werden Initialisierung, Reihenfolge, gemeinsame Fehlerbehandlung und besondere
+Laufvarianten koordiniert.
 
-## Öffentliche Einstiege
+Der reguläre Aufruf über
+[`StartCDSToolChainWithVacuum.sh`](../../StartCDSToolChainWithVacuum.sh) startet
+[`StartCDSToolChain.R`](../StartCDSToolChain.R). Das R-Skript prüft die zusammengehörigen
+Konfigurationen und führt FHIR-Import, Übernahme vorhandener Frontend-Daten, Datenverarbeitung und
+Rückübertragung ins Frontend in ihrer vorgesehenen Reihenfolge aus. Unvollständige frühere Läufe
+können dabei wiederaufgenommen werden. [`StartDataImport.R`](../StartDataImport.R) steuert die
+Importvarianten; [`StartMRPRecalculation.R`](../StartMRPRecalculation.R) koordiniert die additive
+MRP-Neuberechnung. Die Snapshot-Skripte binden das separate
+[`pseudonym`](../pseudonym/README.md)-Paket ein.
 
-Das Paket exportiert derzeit keine R-Funktionen; seine [`NAMESPACE`](NAMESPACE) ist leer. Die
-tatsächlichen Einstiege liegen als Skripte im übergeordneten Verzeichnis:
+Das Paketverzeichnis `R-cdstoolchain/cdstoolchain` enthält derzeit nur das R-Paketgerüst; die
+operative Orchestrierung liegt in den genannten Skripten im übergeordneten Verzeichnis. Der
+vorhandene `testthat`-Test unter [`tests/testthat`](tests/testthat) ist ebenfalls noch ein Gerüsttest.
 
-- [`StartCDSToolChainWithVacuum.sh`](../../StartCDSToolChainWithVacuum.sh) ist der dokumentierte
-  Einstieg für den vollständigen regulären Lauf einschließlich `VACUUM (ANALYZE)`.
-- [`StartCDSToolChain.R`](../StartCDSToolChain.R) führt die reguläre Modulkette aus.
-- [`StartDataImport.R`](../StartDataImport.R) steuert vollständige oder ressourcenbezogene Importe.
-- [`StartMRPRecalculation.R`](../StartMRPRecalculation.R) startet die additive MRP-Neuberechnung.
-- Die Snapshot-Skripte verwenden das separate [`pseudonym`](../pseudonym/README.md)-Paket.
-
-Die projektweite Verwendung erläutert die [zentrale README](../../README.md). Details zur
-Einrichtung und zum Betrieb stehen in [`Install.md`](../../Install.md) und
-[`Operation.md`](../../Operation.md); die MRP-Neuberechnung ist in
-[`README_MRP_Recalculation.md`](../README_MRP_Recalculation.md) beschrieben.
-
-## Tests und Modulschnittstellen
-
-Der `testthat`-Einstieg liegt unter [`tests/testthat`](tests/testthat); der aktuelle Pakettest ist
-noch ein Gerüsttest. Das Verhalten der delegierten Schritte wird in den jeweiligen Modulpaketen
-getestet und dokumentiert: [`cds2db`](../../R-cds2db/cds2db/README.md),
-[`dataprocessor`](../../R-dataprocessor/dataprocessor/README.md),
-[`db2frontend`](../../R-db2frontend/README.md) und [`etlutils`](../../R-etlutils/etlutils/README.md).
+Die projektweite Ausführung ist in der [zentralen README](../../README.md) beschrieben. Weitere
+Details stehen in [`Install.md`](../../Install.md), [`Operation.md`](../../Operation.md) und für die
+MRP-Neuberechnung in [`README_MRP_Recalculation.md`](../README_MRP_Recalculation.md).

--- a/R-cdstoolchain/pseudonym/README.md
+++ b/R-cdstoolchain/pseudonym/README.md
@@ -1,0 +1,32 @@
+# pseudonym
+
+`pseudonym` stellt die Pseudonymisierungslogik für INTERPOLAR-Snapshot-Datenbanken
+bereit. Das Paket übersetzt FHIR-Regeln in Table Descriptions, prüft Regeln und
+Mapping-Abdeckung und materialisiert pseudonymisierte beziehungsweise technische
+Broad-Consent-Snapshot-Datenbanken. Den Datei- und Datenbanklebenszyklus steuert hingegen
+[`ip-snapshot.sh`](../../ip-snapshot.sh); FHIR-Import, fachliche Verarbeitung und
+Frontend-Synchronisation bleiben Aufgaben der übrigen Module.
+
+## Öffentliche Einstiege
+
+Die [`NAMESPACE`](NAMESPACE) exportiert:
+
+- `setFhirPseudonymizationRules()` zum Ergänzen einer expandierten FHIR Table Description,
+- `preflightSnapshotPseudonymization()` zur Regel- und Mapping-Prüfung,
+- `pseudonymizeSnapshotDatabase()` zur materialisierten Pseudonymisierung einer Snapshot-Datenbank,
+- `createBroadConsentSnapshotDatabase()` für den technischen Broad-Consent-Snapshot.
+
+Die R-seitigen Einstiegsskripte sind
+[`StartSnapshotPseudonymization.R`](../StartSnapshotPseudonymization.R),
+[`StartSnapshotPseudonymizationPreflight.R`](../StartSnapshotPseudonymizationPreflight.R) und
+[`StartBroadConsentSnapshot.R`](../StartBroadConsentSnapshot.R). Bedienung, Voraussetzungen,
+Prüfhinweise und technische Details des regulären Ablaufs beschreibt
+[`Database_Snapshot.md`](../../Database_Snapshot.md).
+
+## Tests und weitere Orientierung
+
+Die paketbezogenen `testthat`-Tests liegen unter [`tests/testthat`](tests/testthat) und decken
+Regelübersetzung, Mapping-Prüfung, tabellen- und chunkweise Pseudonymisierung,
+Snapshot-Materialisierung, Anreicherungen und den Broad-Consent-Ablauf ab. Der Gesamtaufbau der
+CDS Tool Chain ist in der [zentralen README](../../README.md) beschrieben; Installation und Betrieb
+sind in [`Install.md`](../../Install.md) und [`Operation.md`](../../Operation.md) dokumentiert.

--- a/R-cdstoolchain/pseudonym/README.md
+++ b/R-cdstoolchain/pseudonym/README.md
@@ -1,32 +1,23 @@
 # pseudonym
 
-`pseudonym` stellt die Pseudonymisierungslogik für INTERPOLAR-Snapshot-Datenbanken
-bereit. Das Paket übersetzt FHIR-Regeln in Table Descriptions, prüft Regeln und
-Mapping-Abdeckung und materialisiert pseudonymisierte beziehungsweise technische
-Broad-Consent-Snapshot-Datenbanken. Den Datei- und Datenbanklebenszyklus steuert hingegen
-[`ip-snapshot.sh`](../../ip-snapshot.sh); FHIR-Import, fachliche Verarbeitung und
-Frontend-Synchronisation bleiben Aufgaben der übrigen Module.
+Das Paket `pseudonym` enthält die Logik zum Erzeugen pseudonymisierter
+INTERPOLAR-Snapshot-Datenbanken. Es liest die Pseudonymisierungsregeln aus den Table Descriptions,
+prüft Regeln und benötigte Mapping-Werte und verarbeitet die ausgewählten Datenbanktabellen
+chunkweise. Dabei entstehen auch die zusätzlichen Auswertungsspalten und Prüfberichte des
+pseudonymisierten Snapshots.
 
-## Öffentliche Einstiege
-
-Die [`NAMESPACE`](NAMESPACE) exportiert:
-
-- `setFhirPseudonymizationRules()` zum Ergänzen einer expandierten FHIR Table Description,
-- `preflightSnapshotPseudonymization()` zur Regel- und Mapping-Prüfung,
-- `pseudonymizeSnapshotDatabase()` zur materialisierten Pseudonymisierung einer Snapshot-Datenbank,
-- `createBroadConsentSnapshotDatabase()` für den technischen Broad-Consent-Snapshot.
-
-Die R-seitigen Einstiegsskripte sind
-[`StartSnapshotPseudonymization.R`](../StartSnapshotPseudonymization.R),
+[`ip-snapshot.sh`](../../ip-snapshot.sh) steuert außerhalb des Pakets den Datei- und
+Datenbanklebenszyklus. Für seine Vorprüfung und Pseudonymisierung ruft es
 [`StartSnapshotPseudonymizationPreflight.R`](../StartSnapshotPseudonymizationPreflight.R) und
-[`StartBroadConsentSnapshot.R`](../StartBroadConsentSnapshot.R). Bedienung, Voraussetzungen,
-Prüfhinweise und technische Details des regulären Ablaufs beschreibt
+[`StartSnapshotPseudonymization.R`](../StartSnapshotPseudonymization.R) auf; diese übergeben die
+eigentliche Verarbeitung an `pseudonym`. Der technische Broad-Consent-Schritt läuft entsprechend
+über [`StartBroadConsentSnapshot.R`](../StartBroadConsentSnapshot.R) und filtert derzeit noch keine
+Daten.
+
+FHIR-Import, reguläre fachliche Verarbeitung und Frontend-Synchronisation gehören nicht zu diesem
+Paket. Den vollständigen Snapshot-Ablauf, die Regeln und die erzeugten Berichte beschreibt
 [`Database_Snapshot.md`](../../Database_Snapshot.md).
 
-## Tests und weitere Orientierung
-
-Die paketbezogenen `testthat`-Tests liegen unter [`tests/testthat`](tests/testthat) und decken
-Regelübersetzung, Mapping-Prüfung, tabellen- und chunkweise Pseudonymisierung,
-Snapshot-Materialisierung, Anreicherungen und den Broad-Consent-Ablauf ab. Der Gesamtaufbau der
-CDS Tool Chain ist in der [zentralen README](../../README.md) beschrieben; Installation und Betrieb
-sind in [`Install.md`](../../Install.md) und [`Operation.md`](../../Operation.md) dokumentiert.
+Die paketbezogenen `testthat`-Tests liegen unter [`tests/testthat`](tests/testthat). Sie prüfen
+insbesondere Regelübersetzung, Mapping-Abdeckung, chunkweise Verarbeitung, Anreicherungen,
+Snapshot-Materialisierung und den technischen Broad-Consent-Ablauf.


### PR DESCRIPTION
## Summary

- describe the pseudonym package responsibilities within the project snapshot workflow
- describe how the project scripts orchestrate cdstoolchain and delegate work to the individual modules
- link to existing operational documentation and package-specific tests without duplicating it

## Checks

- verified that all relative links resolve to existing repository targets
- cross-checked the described behavior against the project shell scripts, R scripts, and package tests
- ran git diff --check
- reviewed the diff for duplication, factual accuracy, and scope expansion

Closes #1347