### PR TITLE
Clarify snapshot deletion and database-name prefix errors

### DIFF
--- a/Database_Snapshot.md
+++ b/Database_Snapshot.md
@@ -202,14 +202,19 @@ werden genauso als Snapshot-Datenbank aktiviert:
 Der Befehl löscht nur die aktivierte Snapshot-Datenbank. Die Snapshot-Datei
 bleibt erhalten.
 
-### Snapshot-Datei und Snapshot-Datenbank löschen
+### Snapshot-Datei löschen
 
 ```bash
 ./ip-snapshot.sh delete snap01_20251002
 ```
 
-Der Befehl löscht die Snapshot-Datei und eine gegebenenfalls vorhandene,
-gleichnamige Snapshot-Datenbank.
+Der Befehl löscht ausschließlich die Snapshot-Datei. Eine gegebenenfalls
+aktivierte Snapshot-Datenbank bleibt erhalten und muss separat mit `deactivate`
+entfernt werden.
+
+`delete` erwartet den in der Dateiliste ausgegebenen Namen ohne die Erweiterung
+`.sql.gz`. Das Präfix `ip_` gehört nur zum Datenbanknamen und darf hier nicht
+angegeben werden.
 
 ## Ablauf bis zur Prüfung
 

--- a/ip-snapshot.sh
+++ b/ip-snapshot.sh
@@ -29,7 +29,8 @@ Usage: ${0##*/} <action> <name>
              "pseudonymize" – creates a pseudonymized snapshot <name_date>_pseud.sql.gz
              "create-broad-consent"
                            – creates a Broad Consent snapshot from an activated snapshot database
-             "delete"      – deletes a snapshot <name_date>.sql.gz
+             "delete"      – deletes only a snapshot file <name_date>.sql.gz;
+                              expects the file name without the database prefix "ip_"
              "activate"    – activates a snapshot <name_date>.sql.gz by creating a database for it
              "deactivate"  – deactivates a snapshot database; accepts <name_date> and the
                               ip_<name_date> name printed by "list"
@@ -790,6 +791,13 @@ case "$action" in
         # 1. Existenz‑ und Typ‑Prüfung
         # ------------------------------------------------------------
         if [[ ! -f "$file_path" ]]; then
+            if [[ "$name" == ip_* ]]; then
+                snapshot_file_name="${name#ip_}"
+                echo "Error: \"${name}\" is a snapshot database name, not a snapshot file name." >&2
+                echo "The \"delete\" action only deletes snapshot files and expects the name without the \"ip_\" prefix." >&2
+                echo "To delete the snapshot file, run: $0 delete ${snapshot_file_name}" >&2
+                exit 1
+            fi
             echo "Error: snapshot \"$file\" does not exist or is not a regular file."
             # kein exit – das Skript läuft weiter
             # break

--- a/tools/test-ip-snapshot.sh
+++ b/tools/test-ip-snapshot.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+test_dir="$(mktemp -d)"
+trap 'rm -rf "${test_dir}"' EXIT
+
+cp "${repo_root}/ip-snapshot.sh" "${test_dir}/ip-snapshot.sh"
+mkdir "${test_dir}/Snapshots"
+
+snapshot_script="${test_dir}/ip-snapshot.sh"
+database_name="ip_snapshot_20260903_pseud"
+expected_file_name="snapshot_20260903_pseud"
+
+set +e
+output="$(cd "${test_dir}" && "${snapshot_script}" delete "${database_name}" 2>&1)"
+status=$?
+set -e
+
+if [[ ${status} -eq 0 ]]; then
+    echo "Expected delete with a snapshot database name to fail." >&2
+    exit 1
+fi
+
+if [[ "${output}" != *"\"${database_name}\" is a snapshot database name, not a snapshot file name."* ]]; then
+    echo "Expected the error to identify the snapshot database name." >&2
+    exit 1
+fi
+
+if [[ "${output}" != *"delete ${expected_file_name}"* ]]; then
+    echo "Expected the error to show the delete command without the database prefix." >&2
+    exit 1
+fi
+
+echo "Snapshot command tests passed."


### PR DESCRIPTION
## Summary

- clarify that `delete` removes only snapshot files and expects names without the database prefix `ip_`
- provide an actionable error message when a snapshot database name is passed to `delete`
- correct the snapshot documentation so it no longer claims that `delete` also drops a database
- add an isolated regression test for the database-name mix-up

## Testing

- `Rscript tools/style-full.R`
- `bash -n ip-snapshot.sh tools/test-ip-snapshot.sh`
- `tools/test-ip-snapshot.sh`
- `shellcheck --severity=warning ip-snapshot.sh tools/test-ip-snapshot.sh`
- `git diff --check origin/develop...HEAD`

Closes #1409