### PR TITLE
Prevent duplicate MRP entries during recalculation

### DIFF
--- a/R-cdstoolchain/README_MRP_Recalculation.md
+++ b/R-cdstoolchain/README_MRP_Recalculation.md
@@ -8,7 +8,11 @@ domain-specific MRP key.
 
 Existing data is not deleted from the database or from REDCap. Already existing
 retrospective MRP evaluations are identified using patient/record, medication
-analysis, reference timestamp, short description, ATC values, and MRP class.
+analysis, ATC values, and MRP class. The generated short description and its
+reference timestamp are deliberately excluded: additional source evidence can
+change these presentation values without creating a clinically new MRP. The
+comparison retains the number of MRPs per key, because different fixed WP7 rules
+can legitimately share the same visible values.
 
 ## Flow
 
@@ -37,10 +41,13 @@ in `R-cdstoolchain`, while the actual dataprocessor logic stays inside the
 3. Re-run the normal retrospective MRP calculation for these encounters.
 
 4. Compare the resulting MRP candidates with already existing rows in
-   `v_retrolektive_mrpbewertung_fe`.
+   `v_retrolektive_mrpbewertung_fe`. Existing rows are loaded in bounded
+   `record_id` chunks, with one query per chunk rather than one query per MRP.
 
-5. Keep only clinically new retrospective MRP evaluations and reduce the
-   matching `dp_mrp_calculations` rows to the same `ret_id` set.
+5. Subtract the existing MRP count per comparison key from the recalculated
+   candidates and reduce the matching `dp_mrp_calculations` rows to the
+   surviving `ret_id` set. Exact legacy matches are subtracted first when
+   several fixed WP7 rules share a visible key.
 
 6. Reassign `redcap_repeat_instance` per `record_id` so that new rows continue
    the current REDCap repeat sequence without collisions.

--- a/R-dataprocessor/dataprocessor/R/04_MRP_Recalculation.R
+++ b/R-dataprocessor/dataprocessor/R/04_MRP_Recalculation.R
@@ -1,3 +1,91 @@
+normalizeMRPRecalculationKeyColumn <- function(value) {
+  if (inherits(value, "POSIXct")) {
+    value <- format(value, "%Y-%m-%d %H:%M:%S", tz = "UTC")
+  } else {
+    value <- as.character(value)
+  }
+  value[is.na(value)] <- "#NULL#"
+  trimws(value)
+}
+
+addMRPRecalculationKey <- function(dt, key_cols) {
+  dt[, .mrp_recalculation_key := do.call(
+    paste,
+    c(lapply(.SD, normalizeMRPRecalculationKeyColumn), sep = "|||")
+  ), .SDcols = key_cols]
+}
+
+filterExistingMRPRows <- function(current_table, existing_table, key_cols, exact_key_cols = character()) {
+  if (!nrow(current_table)) {
+    return(current_table)
+  }
+
+  current_table <- data.table::copy(current_table)
+  existing_table <- data.table::copy(existing_table)
+  current_table[, .mrp_recalculation_order := .I]
+  addMRPRecalculationKey(current_table, key_cols)
+  if (!nrow(existing_table)) {
+    current_table[, c(".mrp_recalculation_order", ".mrp_recalculation_key") := NULL]
+    return(current_table)
+  }
+
+  addMRPRecalculationKey(existing_table, key_cols)
+
+  # Prefer candidates that match an existing row on the complete legacy key
+  # when more than one fixed WP7 rule shares the same visible MRP key. This
+  # makes the legacy comparison a multiset subtraction instead of suppressing
+  # every candidate with that key.
+  current_table[, .mrp_recalculation_exact_match := FALSE]
+  if (length(exact_key_cols)) {
+    current_exact <- data.table::copy(current_table)
+    existing_exact <- data.table::copy(existing_table)
+    addMRPRecalculationKey(current_exact, exact_key_cols)
+    addMRPRecalculationKey(existing_exact, exact_key_cols)
+    current_table[, .mrp_recalculation_exact_match :=
+      current_exact$.mrp_recalculation_key %in% existing_exact$.mrp_recalculation_key]
+  }
+
+  existing_identity_cols <- c(".mrp_recalculation_key", intersect("ret_id", names(existing_table)))
+  existing_counts <- unique(existing_table[, ..existing_identity_cols])[
+    , .mrp_recalculation_existing_count := .N,
+    by = .mrp_recalculation_key
+  ]
+  current_table <- merge(
+    current_table,
+    existing_counts,
+    by = ".mrp_recalculation_key",
+    all.x = TRUE,
+    sort = FALSE
+  )
+  current_table[is.na(.mrp_recalculation_existing_count), .mrp_recalculation_existing_count := 0L]
+
+  data.table::setorder(
+    current_table,
+    .mrp_recalculation_key,
+    -.mrp_recalculation_exact_match,
+    .mrp_recalculation_order
+  )
+  current_table[, .mrp_recalculation_rank := seq_len(.N), by = .mrp_recalculation_key]
+  current_table <- current_table[
+    .mrp_recalculation_rank > .mrp_recalculation_existing_count
+  ]
+  data.table::setorder(current_table, .mrp_recalculation_order)
+  current_table[, c(
+    ".mrp_recalculation_order",
+    ".mrp_recalculation_key",
+    ".mrp_recalculation_exact_match",
+    ".mrp_recalculation_existing_count",
+    ".mrp_recalculation_rank"
+  ) := NULL]
+
+  current_table
+}
+
+splitMRPRecordIds <- function(record_ids, chunk_size = 1000L) {
+  record_ids <- unique(na.omit(record_ids))
+  split(record_ids, ceiling(seq_along(record_ids) / chunk_size))
+}
+
 #' Recalculate retrospective MRPs additively for a selected time range
 #'
 #' Re-runs the retrospective MRP calculation for encounters in the given time
@@ -29,53 +117,35 @@ recalculateMRPs <- function(start_date,
     stop("Parameter end_date (", end_date, ") must be greater than start_date (", start_date, ").")
   }
 
-  # Normalize values that are part of the logical MRP identity so that
-  # comparisons are stable across character, NA, and timestamp columns.
-  normalizeMRPKeyColumn <- function(value) {
-    if (inherits(value, "POSIXct")) {
-      value <- format(value, "%Y-%m-%d %H:%M:%S", tz = GLOBAL_TIMEZONE)
-    } else {
-      value <- as.character(value)
-    }
-    value[is.na(value)] <- "#NULL#"
-    trimws(value)
-  }
-
-  # Build one comparable key from the clinically relevant MRP columns.
-  addMRPKey <- function(dt, key_cols) {
-    dt[, .mrp_recalculation_key := do.call(
-      paste,
-      c(lapply(.SD, normalizeMRPKeyColumn), sep = "|||")
-    ), .SDcols = key_cols]
-  }
-
-  # Load existing rows for the same logical scope from the database and remove
-  # all currently prepared rows that already exist on the given key.
-  filterExistingRows <- function(current_table, key_cols, query = NULL, lock_id = NULL) {
-    if (!nrow(current_table)) {
-      return(current_table)
+  # Load only the columns needed for duplicate detection and renumbering. The
+  # query is chunked by record_id to keep memory and SQL statement sizes bounded
+  # without introducing per-record database round trips.
+  loadExistingMRPRows <- function(record_ids, key_cols, chunk_size = 1000L) {
+    chunks <- splitMRPRecordIds(record_ids, chunk_size)
+    if (!length(chunks)) {
+      return(data.table::data.table())
     }
 
-    existing_table <- data.table::data.table()
-    if (!is.null(query)) {
-      existing_table <- etlutils::dbGetReadOnlyQuery(query, lock_id = lock_id)
-    }
+    existing_chunks <- lapply(seq_along(chunks), function(chunk_index) {
+      query <- paste0(
+        "SELECT ", paste(unique(c(key_cols, "ret_id", "redcap_repeat_instance")), collapse = ", "), "\n",
+        "FROM v_retrolektive_mrpbewertung_fe\n",
+        "WHERE record_id IN ", etlutils::fhirdbGetQueryList(chunks[[chunk_index]]), "\n"
+      )
+      etlutils::dbGetReadOnlyQuery(
+        query,
+        lock_id = paste0("MRP_Recalculation_existing_mrps_", chunk_index)
+      )
+    })
 
-    addMRPKey(current_table, key_cols)
-    if (nrow(existing_table)) {
-      addMRPKey(existing_table, key_cols)
-      current_table <- current_table[!.mrp_recalculation_key %in% existing_table$.mrp_recalculation_key]
-    }
-    current_table[, .mrp_recalculation_key := NULL]
-
-    current_table
+    data.table::rbindlist(existing_chunks, use.names = TRUE, fill = TRUE)
   }
 
   # ret_id values continue per medication analysis, while REDCap repeat
   # instances continue per patient record. After deduplication, both sequences
   # must be rebuilt from the current last-version state so the surviving new
   # rows remain gap-free and consistent.
-  renumberNewMRPs <- function(mrp_tables) {
+  renumberNewMRPs <- function(mrp_tables, existing_ret_rows) {
     ret_table <- mrp_tables$retrolektive_mrpbewertung_fe
     dp_table <- mrp_tables$dp_mrp_calculations
 
@@ -171,20 +241,6 @@ recalculateMRPs <- function(start_date,
       list(ret_table = ret_table, dp_table = dp_table)
     }
 
-    record_ids <- unique(na.omit(ret_table$record_id))
-    existing_ret_rows <- data.table::data.table()
-    if (length(record_ids)) {
-      query <- paste0(
-        "SELECT record_id, ret_meda_id, ret_id, redcap_repeat_instance\n",
-        "FROM v_retrolektive_mrpbewertung_fe_last_version\n",
-        "WHERE record_id IN ", etlutils::fhirdbGetQueryList(record_ids), "\n"
-      )
-      existing_ret_rows <- etlutils::dbGetReadOnlyQuery(
-        query,
-        lock_id = "MRP_Recalculation_existing_ret_ids_and_repeat_instances"
-      )
-    }
-
     ret_table[, temp_old_ret_id := ret_id]
     ret_table[, temp_old_redcap_repeat_instance := redcap_repeat_instance]
     dp_table[, temp_old_ret_id := ret_id]
@@ -244,78 +300,49 @@ recalculateMRPs <- function(start_date,
       # dp_mrp_calculations rows of those surviving MRPs.
       ret_table <- mrp_tables$retrolektive_mrpbewertung_fe[!is.na(ret_id)]
       dp_table <- mrp_tables$dp_mrp_calculations[!is.na(ret_id)]
+      existing_ret_rows <- data.table::data.table()
       if (!nrow(ret_table)) {
         mrp_tables$retrolektive_mrpbewertung_fe <- ret_table
         mrp_tables$dp_mrp_calculations <- dp_table[0]
       } else {
+        # The display text and reference timestamp are intentionally excluded.
+        # Both can change when additional evidence is loaded although the
+        # underlying clinical MRP is unchanged.
         ret_key_cols <- c(
           "record_id",
           "ret_meda_id",
-          "ret_meda_dat_referenz",
-          "ret_kurzbeschr",
           "ret_atc1",
           "ret_ip_klasse_01",
           "ret_ip_klasse_disease",
           "ret_atc2"
         )
-        ret_meda_ids <- unique(na.omit(ret_table$ret_meda_id))
-        ret_query <- NULL
-        if (length(ret_meda_ids)) {
-          ret_query <- paste0(
-            "SELECT ", paste(
-              ret_key_cols,
-              collapse = ", "
-            ), "\n",
-            "FROM v_retrolektive_mrpbewertung_fe\n",
-            "WHERE ret_meda_id IN ", etlutils::fhirdbGetQueryList(ret_meda_ids), "\n"
-          )
-        }
-        ret_table <- filterExistingRows(
+        exact_ret_key_cols <- c(
+          ret_key_cols,
+          "ret_meda_dat_referenz",
+          "ret_kurzbeschr"
+        )
+        existing_ret_rows <- loadExistingMRPRows(
+          ret_table$record_id,
+          unique(c(ret_key_cols, exact_ret_key_cols))
+        )
+        ret_table <- filterExistingMRPRows(
           current_table = ret_table,
+          existing_table = existing_ret_rows,
           key_cols = ret_key_cols,
-          query = ret_query,
-          lock_id = "MRP_Recalculation_existing_retrolektive_mrpbewertung"
+          exact_key_cols = exact_ret_key_cols
         )
         mrp_tables$retrolektive_mrpbewertung_fe <- ret_table
         mrp_tables$dp_mrp_calculations <- dp_table[ret_id %in% unique(ret_table$ret_id)]
       }
 
-      mrp_tables <- renumberNewMRPs(mrp_tables)
+      mrp_tables <- renumberNewMRPs(mrp_tables, existing_ret_rows)
       mrp_tables <- markRecalculatedMRPs(mrp_tables)
 
-      # Remove dp_mrp_calculations rows that already exist in the database.
-      dp_table <- mrp_tables$dp_mrp_calculations
-      if (nrow(dp_table)) {
-        dp_key_cols <- c(
-          "enc_id",
-          "mrp_calculation_type",
-          "meda_id",
-          "study_phase",
-          "ward_name",
-          "atc1_medreq_fhir_id",
-          "mrp_proxy_type",
-          "mrp_proxy_code",
-          "mrp_proxy_fhir_id"
-        )
-        dp_meda_ids <- unique(na.omit(dp_table$meda_id))
-        dp_query <- NULL
-        if (length(dp_meda_ids)) {
-          dp_query <- paste0(
-            "SELECT ", paste(
-              dp_key_cols,
-              collapse = ", "
-            ), "\n",
-            "FROM v_dp_mrp_calculations\n",
-            "WHERE ret_id IS NOT NULL AND meda_id IN ", etlutils::fhirdbGetQueryList(dp_meda_ids), "\n"
-          )
-        }
-        mrp_tables$dp_mrp_calculations <- filterExistingRows(
-          current_table = dp_table,
-          key_cols = dp_key_cols,
-          query = dp_query,
-          lock_id = "MRP_Recalculation_existing_dp_mrp_calculations"
-        )
-      }
+      # Only rows belonging to surviving new MRPs remain at this point. Remove
+      # exact within-run duplicates without another database query. Including
+      # ret_id preserves audit rows when one source item contributes to more
+      # than one genuinely distinct MRP.
+      mrp_tables$dp_mrp_calculations <- unique(mrp_tables$dp_mrp_calculations)
     })
 
     etlutils::runLevel2("Write new MRP results to database", {

--- a/R-dataprocessor/dataprocessor/R/04_MRP_Recalculation.R
+++ b/R-dataprocessor/dataprocessor/R/04_MRP_Recalculation.R
@@ -47,7 +47,7 @@ filterExistingMRPRows <- function(current_table, existing_table, key_cols, exact
 
   existing_identity_cols <- c(".mrp_recalculation_key", intersect("ret_id", names(existing_table)))
   existing_counts <- unique(existing_table[, ..existing_identity_cols])[
-    , .mrp_recalculation_existing_count := .N,
+    , .(.mrp_recalculation_existing_count = .N),
     by = .mrp_recalculation_key
   ]
   current_table <- merge(
@@ -148,7 +148,6 @@ recalculateMRPs <- function(start_date,
   renumberNewMRPs <- function(mrp_tables, existing_ret_rows) {
     ret_table <- mrp_tables$retrolektive_mrpbewertung_fe
     dp_table <- mrp_tables$dp_mrp_calculations
-
     if (!nrow(ret_table)) {
       return(mrp_tables)
     }
@@ -251,7 +250,6 @@ recalculateMRPs <- function(start_date,
       buildRenumberMap(.SD, existing_ret_rows[record_id == .BY$record_id], .BY$ret_meda_id),
       by = .(record_id, ret_meda_id)
     ]
-
     updated_tables <- applyRenumberMap(ret_table, dp_table, renumber_map)
     ret_table <- updated_tables$ret_table
     dp_table <- updated_tables$dp_table

--- a/R-dataprocessor/dataprocessor/tests/testthat/test-mrp-recalculation.R
+++ b/R-dataprocessor/dataprocessor/tests/testthat/test-mrp-recalculation.R
@@ -1,0 +1,153 @@
+test_that("MRP recalculation ignores presentation-only changes", {
+  key_cols <- c(
+    "record_id",
+    "ret_meda_id",
+    "ret_atc1",
+    "ret_ip_klasse_01",
+    "ret_ip_klasse_disease",
+    "ret_atc2"
+  )
+  existing <- data.table::data.table(
+    record_id = 1L,
+    ret_meda_id = "meda-1",
+    ret_meda_dat_referenz = as.POSIXct("2026-01-01 12:00:00", tz = "UTC"),
+    ret_kurzbeschr = "Old evidence",
+    ret_atc1 = "A01AA01",
+    ret_ip_klasse_01 = "Drug-Disease",
+    ret_ip_klasse_disease = "Disease cluster",
+    ret_atc2 = NA_character_
+  )
+  current <- data.table::copy(existing)
+  current[, `:=`(
+    ret_meda_dat_referenz = as.POSIXct("2026-01-01 12:00:01", tz = "UTC"),
+    ret_kurzbeschr = "Newly loaded evidence"
+  )]
+
+  result <- filterExistingMRPRows(
+    current,
+    existing,
+    key_cols,
+    c(key_cols, "ret_meda_dat_referenz", "ret_kurzbeschr")
+  )
+
+  expect_equal(nrow(result), 0L)
+})
+
+test_that("MRP recalculation keeps clinically distinct candidates", {
+  key_cols <- c(
+    "record_id",
+    "ret_meda_id",
+    "ret_atc1",
+    "ret_ip_klasse_01",
+    "ret_ip_klasse_disease",
+    "ret_atc2"
+  )
+  existing <- data.table::data.table(
+    record_id = 1L,
+    ret_meda_id = "meda-1",
+    ret_atc1 = "A01AA01",
+    ret_ip_klasse_01 = "Drug-Disease",
+    ret_ip_klasse_disease = "Disease cluster",
+    ret_atc2 = NA_character_
+  )
+  current <- data.table::copy(existing)
+  current[, ret_atc1 := "A01AA02"]
+
+  result <- filterExistingMRPRows(current, existing, key_cols)
+
+  expect_equal(nrow(result), 1L)
+  expect_equal(result$ret_atc1, "A01AA02")
+})
+
+test_that("MRP recalculation preserves fixed rules sharing the visible key", {
+  key_cols <- c(
+    "record_id",
+    "ret_meda_id",
+    "ret_atc1",
+    "ret_ip_klasse_01",
+    "ret_ip_klasse_disease",
+    "ret_atc2"
+  )
+  current <- data.table::data.table(
+    record_id = c(1L, 1L),
+    ret_meda_id = c("meda-1", "meda-1"),
+    ret_kurzbeschr = c("Direct diagnosis", "New proxy evidence"),
+    ret_atc1 = c("A01AA01", "A01AA01"),
+    ret_ip_klasse_01 = c("Drug-Disease", "Drug-Disease"),
+    ret_ip_klasse_disease = c("Disease cluster", "Disease cluster"),
+    ret_atc2 = c(NA_character_, NA_character_)
+  )
+
+  result <- filterExistingMRPRows(current, data.table::data.table(), key_cols)
+
+  expect_equal(nrow(result), 2L)
+  expect_false(".mrp_recalculation_key" %in% names(result))
+})
+
+test_that("MRP recalculation subtracts legacy rows by key cardinality", {
+  key_cols <- c(
+    "record_id",
+    "ret_meda_id",
+    "ret_atc1",
+    "ret_ip_klasse_01",
+    "ret_ip_klasse_disease",
+    "ret_atc2"
+  )
+  existing <- data.table::data.table(
+    record_id = 1L,
+    ret_id = "meda-1-r1",
+    ret_meda_id = "meda-1",
+    ret_meda_dat_referenz = as.POSIXct("2026-01-01 12:00:00", tz = "UTC"),
+    ret_kurzbeschr = "Existing fixed rule",
+    ret_atc1 = "A01AA01",
+    ret_ip_klasse_01 = "Drug-Disease",
+    ret_ip_klasse_disease = "Disease cluster",
+    ret_atc2 = NA_character_
+  )
+  current <- data.table::rbindlist(list(
+    data.table::copy(existing)[, ret_id := "temporary-r1"],
+    data.table::copy(existing)[, `:=`(
+      ret_id = "temporary-r2",
+      ret_kurzbeschr = "Newly triggered fixed rule"
+    )]
+  ))
+
+  result <- filterExistingMRPRows(
+    current,
+    existing,
+    key_cols,
+    c(key_cols, "ret_meda_dat_referenz", "ret_kurzbeschr")
+  )
+
+  expect_equal(nrow(result), 1L)
+  expect_equal(result$ret_kurzbeschr, "Newly triggered fixed rule")
+})
+
+test_that("MRP history versions do not inflate the legacy count", {
+  key_cols <- c("record_id", "ret_meda_id", "ret_atc1")
+  existing <- data.table::data.table(
+    record_id = c(1L, 1L),
+    ret_id = c("meda-1-r1", "meda-1-r1"),
+    ret_meda_id = c("meda-1", "meda-1"),
+    ret_atc1 = c("A01AA01", "A01AA01"),
+    ret_kurzbeschr = c("Old version", "New version")
+  )
+  current <- data.table::data.table(
+    record_id = c(1L, 1L),
+    ret_id = c("temporary-r1", "temporary-r2"),
+    ret_meda_id = c("meda-1", "meda-1"),
+    ret_atc1 = c("A01AA01", "A01AA01"),
+    ret_kurzbeschr = c("Changed first rule", "Second fixed rule")
+  )
+
+  result <- filterExistingMRPRows(current, existing, key_cols)
+
+  expect_equal(nrow(result), 1L)
+})
+
+test_that("MRP record IDs are chunked without splitting or repeating records", {
+  chunks <- splitMRPRecordIds(c(3L, 1L, 2L, 3L, NA_integer_, 4L, 5L), chunk_size = 2L)
+
+  expect_equal(unname(lengths(chunks)), c(2L, 2L, 1L))
+  expect_equal(unname(unlist(chunks)), c(3L, 1L, 2L, 4L, 5L))
+})

--- a/R-dataprocessor/dataprocessor/tests/testthat/test-mrp-recalculation.R
+++ b/R-dataprocessor/dataprocessor/tests/testthat/test-mrp-recalculation.R
@@ -120,6 +120,8 @@ test_that("MRP recalculation subtracts legacy rows by key cardinality", {
   )
 
   expect_equal(nrow(result), 1L)
+  expect_equal(result$ret_id, "temporary-r2")
+  expect_false(any(c("ret_id.x", "ret_id.y") %in% names(result)))
   expect_equal(result$ret_kurzbeschr, "Newly triggered fixed rule")
 })
 


### PR DESCRIPTION
Closes #1326

## Änderung

- verwendet für den Legacy-Abgleich einen stabilen MRP-Schlüssel ohne generierte Kurzbeschreibung und Referenzzeitpunkt
- zieht vorhandene MRPs pro Schlüssel als Multimenge ab, damit mehrere feste WP7-Regeln mit gleichen sichtbaren Feldern erhalten bleiben
- lädt Altbestände gebündelt in begrenzten `record_id`-Chunks und verwendet dieselben Daten anschließend auch für die Neunummerierung
- entfernt die zusätzliche Datenbankabfrage für bereits vorhandene `dp_mrp_calculations`

## Tests

- `Rscript tools/style-full.R`
- Data-Processor-Testthat-Suite: 118 Tests erfolgreich
- isolierte Datenbank `ip_issue1326_mrp_test_20260903` auf Basis des Release-Test-Snapshots:
  - erster Lauf: 30 MRP-Bewertungen / 61 Nachweiszeilen angelegt
  - zweiter Lauf: keine neuen MRP-Bewertungen
  - nach Änderung der Kurzbeschreibung einer vorhandenen MRP: weiterhin keine neue MRP-Bewertung
- `R CMD check --no-manual dataprocessor` startet nicht, da im bestehenden `DESCRIPTION` die Pflichtfelder `Author` und `Maintainer` fehlen