### PR TITLE
Allow manual analyses on older snapshot versions

### DIFF
--- a/Database_Snapshot.md
+++ b/Database_Snapshot.md
@@ -313,6 +313,12 @@ starten manuelle Projekte nur auf pseudonymisierten Snapshot-Datenbanken, die in
 sind. Eine andere kompatible Datenbank, zum Beispiel ein normaler Snapshot oder
 die Originaldatenbank, kann nur bewusst mit `--force` verwendet werden.
 
+Die Versionsprüfung blockiert manuelle Auswertungen nicht, wenn der ausgewählte
+Snapshot älter als die verwendete INTERPOLAR-Version ist. Stattdessen wird der
+Versionsunterschied als Warnung protokolliert. Neuere Datenbankversionen bleiben
+gesperrt. Ob eine konkrete Auswertung mit dem älteren Schema kompatibel ist,
+ergibt sich aus den von ihr tatsächlich benötigten Views und Spalten.
+
 ### Inhalt der pseudonymisierten Snapshot-Datei und Snapshot-Datenbank
 
 Die pseudonymisierte Snapshot-Datei und die pseudonymisierte Snapshot-Datenbank

--- a/R-dataprocessor/README.md
+++ b/R-dataprocessor/README.md
@@ -33,6 +33,13 @@ beabsichtigt, muss zusätzlich `--force` übergeben werden. Beispiel:
 docker compose run --rm --no-deps r-env Rscript R-dataprocessor/StartDataProcessor.R mrp-check --force
 ```
 
+Bei manuellen Projekten darf die in `v_db_parameter` gespeicherte
+Datenbankversion älter als die verwendete INTERPOLAR-Version sein. Der Lauf wird
+dann mit einer Warnung fortgesetzt, damit historische Snapshots auswertbar
+bleiben. Eine neuere Datenbankversion wird weiterhin abgelehnt. Fehlen einer
+Auswertung benötigte Views oder Spalten, meldet die konkrete Datenbankabfrage
+die strukturelle Inkompatibilität.
+
 ### Anpassung der Codes für Körpergröße, -gewicht und BMI
 
 Im Abschnitt "analyse" in der toml-Datei können die auf dem FHIR-Server verfügbaren Codes und Codesysteme für Körpergröße, -gewicht und BMI eingestellt werden. Es werden nur Observationen gefunden, die genau diese Codes enthalten.

--- a/R-dataprocessor/dataprocessor/R/00_Main.R
+++ b/R-dataprocessor/dataprocessor/R/00_Main.R
@@ -145,10 +145,14 @@ startDataprocessorModule <- function(
 }
 
 sourceDataprocessorSubmodules <- function(ignore_newer_db_version = FALSE,
-                                          source_submodule_functions = FALSE) {
+                                          source_submodule_functions = FALSE,
+                                          allow_older_db_version = FALSE) {
   etlutils::runLevel2("Reset database lock from unfinished previous run", {
     etlutils::dbResetLock()
-    etlutils::checkVersion(ignore_newer_db_version)
+    etlutils::checkVersion(
+      ignore_newer_db_version,
+      allow_older_db_version = allow_older_db_version
+    )
   })
 
   if (source_submodule_functions) {
@@ -179,9 +183,13 @@ processData <- function(
 ) {
   # Initialize and start module
   startDataprocessorModule(validate_config, command_line_args)
+  manual_start <- length(getCalledManualStartSubmoduleDirs(command_line_args)) > 0L
 
   try(etlutils::runLevel1("Run Dataprocessor", {
-    sourceDataprocessorSubmodules(ignore_newer_db_version)
+    sourceDataprocessorSubmodules(
+      ignore_newer_db_version,
+      allow_older_db_version = manual_start
+    )
 
     etlutils::runLevel2("Run dataprocessor submodules", {
       runSubmodules(command_line_args)

--- a/R-dataprocessor/dataprocessor/tests/testthat/test-manual-project-database.R
+++ b/R-dataprocessor/dataprocessor/tests/testthat/test-manual-project-database.R
@@ -96,6 +96,47 @@ test_that("project database selection precedes module startup", {
   expect_equal(result, config)
 })
 
+test_that("only manual processing allows an older database version", {
+  called_manual_dirs <- "/manual_start/Statistical_Reports"
+  version_checks <- list()
+  testthat::local_mocked_bindings(
+    startDataprocessorModule = function(...) list(),
+    getCalledManualStartSubmoduleDirs = function(...) called_manual_dirs,
+    sourceDataprocessorSubmodules = function(
+                                             ignore_newer_db_version,
+                                             source_submodule_functions = FALSE,
+                                             allow_older_db_version = FALSE
+    ) {
+      version_checks[[length(version_checks) + 1L]] <<- list(
+        ignore_newer_db_version = ignore_newer_db_version,
+        allow_older_db_version = allow_older_db_version
+      )
+    },
+    runSubmodules = function(...) NULL,
+    .package = "dataprocessor"
+  )
+  testthat::local_mocked_bindings(
+    runLevel1 = function(description, code) force(code),
+    runLevel2 = function(description, code) force(code),
+    dbCloseAllConnections = function() NULL,
+    generateFinishMessage = function() "finished",
+    finalize = function(...) 0L,
+    .package = "etlutils"
+  )
+
+  expect_equal(
+    processData(command_line_args = "statistical-reports"),
+    0L
+  )
+  called_manual_dirs <- character()
+  expect_equal(processData(command_line_args = character()), 0L)
+
+  expect_false(version_checks[[1]]$ignore_newer_db_version)
+  expect_true(version_checks[[1]]$allow_older_db_version)
+  expect_false(version_checks[[2]]$ignore_newer_db_version)
+  expect_false(version_checks[[2]]$allow_older_db_version)
+})
+
 test_that("manual projects inherit the normal connection and select DB_NAME", {
   test_dir <- file.path(tempdir(), "manual-project-config")
   project_dir <- file.path(test_dir, "WP8_export")

--- a/R-etlutils/etlutils/R/lib_envir.R
+++ b/R-etlutils/etlutils/R/lib_envir.R
@@ -750,7 +750,8 @@ getReleaseVersion <- function() {
 #' version expected by the R project and enforces compatibility rules.
 #'
 #' If the database version is older than the release version, execution is
-#' stopped and the user is instructed to run the required database migrations.
+#' stopped and the user is instructed to run the required database migrations,
+#' unless historical database analysis was explicitly enabled by the caller.
 #'
 #' If the database version is newer than the release version, execution is
 #' stopped unless explicitly allowed. Allowing newer database versions is
@@ -764,23 +765,40 @@ getReleaseVersion <- function() {
 #'   version. If \code{FALSE}, execution is stopped and the user is instructed
 #'   to explicitly force the run. If \code{TRUE}, newer database versions are
 #'   accepted.
+#' @param allow_older_db_version Logical flag indicating whether execution
+#'   should continue with a warning when the database version is older than the
+#'   release version. This is intended for analyses of historical snapshots.
+#'   Default is \code{FALSE}.
 #'
 #' @return Invisibly returns \code{NULL}. This function is called for its side
 #'   effects and will stop execution with an error if version compatibility
 #'   requirements are not met.
 #'
 #' @export
-checkVersion <- function(ignore_newer_db_version) {
+checkVersion <- function(ignore_newer_db_version, allow_older_db_version = FALSE) {
   if (!isDefinedAndTrue("VERSION_ALREADY_CHECKED", .lib_envir_env)) {
     db_version <- dbGetVersion()
     # read the first line of the release-version.txt file in the main directory
     release_version <- getReleaseVersion()
     compare_result <- compareVersionsSemver(db_version, release_version)
-    if (compare_result < 0L) { # DB is older than release version -> stop execution
-      stop(paste0(
-        "The database version '", db_version, "' is older than the release version '", release_version, "'. Please update the database via migration.\n",
-        "  See https://github.com/medizininformatik-initiative/INTERPOLAR/discussions/749 for more details."
-      ))
+    if (compare_result < 0L) { # DB is older than release version
+      version_message <- paste0(
+        "The database version '", db_version,
+        "' is older than the release version '", release_version, "'."
+      )
+      if (allow_older_db_version) {
+        warning(
+          version_message,
+          " Continuing with the manual analysis of this historical database.",
+          call. = FALSE
+        )
+      } else {
+        stop(paste0(
+          version_message,
+          " Please update the database via migration.\n",
+          "  See https://github.com/medizininformatik-initiative/INTERPOLAR/discussions/749 for more details."
+        ))
+      }
     } else if (compare_result > 0L) { # DB is newer than release version -> allow force run
       if (!ignore_newer_db_version) {
         stop(paste0(

--- a/R-etlutils/etlutils/tests/testthat/test-lib_envir.R
+++ b/R-etlutils/etlutils/tests/testthat/test-lib_envir.R
@@ -80,3 +80,66 @@ test_that("Variable is empty or missing in a named list", {
   expect_false(isDefinedAndNotEmpty("var3", envir = test_config))
   expect_false(isDefinedAndNotEmpty("var4", envir = test_config))
 })
+
+################
+# checkVersion #
+################
+
+resetVersionCheck <- function() {
+  .lib_envir_env[["VERSION_ALREADY_CHECKED"]] <- NULL
+}
+
+test_that("older database versions remain blocked by default", {
+  resetVersionCheck()
+  on.exit(resetVersionCheck())
+  testthat::local_mocked_bindings(
+    dbGetVersion = function() "2.0.0",
+    getReleaseVersion = function() "2.1.0",
+    .package = "etlutils"
+  )
+
+  expect_error(
+    checkVersion(ignore_newer_db_version = FALSE),
+    "database version '2.0.0' is older than the release version '2.1.0'"
+  )
+})
+
+test_that("older database versions warn but continue for historical analyses", {
+  resetVersionCheck()
+  on.exit(resetVersionCheck())
+  testthat::local_mocked_bindings(
+    dbGetVersion = function() "2.0.0",
+    getReleaseVersion = function() "2.1.0",
+    .package = "etlutils"
+  )
+
+  expect_warning(
+    checkVersion(
+      ignore_newer_db_version = FALSE,
+      allow_older_db_version = TRUE
+    ),
+    paste0(
+      "database version '2.0.0' is older than the release version '2.1.0'. ",
+      "Continuing with the manual analysis"
+    )
+  )
+  expect_true(isDefinedAndTrue("VERSION_ALREADY_CHECKED", .lib_envir_env))
+})
+
+test_that("newer database versions remain blocked for historical analyses", {
+  resetVersionCheck()
+  on.exit(resetVersionCheck())
+  testthat::local_mocked_bindings(
+    dbGetVersion = function() "2.2.0",
+    getReleaseVersion = function() "2.1.0",
+    .package = "etlutils"
+  )
+
+  expect_error(
+    checkVersion(
+      ignore_newer_db_version = FALSE,
+      allow_older_db_version = TRUE
+    ),
+    "database version '2.2.0' is newer than the release version '2.1.0'"
+  )
+})


### PR DESCRIPTION
## Zusammenfassung

- erlaubt manuell gestartete Data-Processor-Auswertungen auf älteren Datenbank-Snapshots
- protokolliert die abweichende Snapshot-Version als Warnung
- lässt die strenge Versionsprüfung der normalen Toolchain und die Sperre neuerer Datenbankversionen unverändert
- überlässt tatsächliche Schema-Inkompatibilitäten den konkreten Abfragen der jeweiligen Auswertung
- dokumentiert das Verhalten für Data Processor und Snapshots

## Tests

- `Rscript tools/style-full.R`
- vollständige `etlutils`-Tests: 637 bestanden
- vollständige `dataprocessor`-Tests: 126 bestanden
- read-only Integrationstest gegen Snapshot 2.0.0 mit Tool-Version 2.1.0: Warnung ausgegeben, Versionsprüfung fortgesetzt

Closes #1412