### PR TITLE
Preserve original errors in REDCap, database and file imports

### DIFF
--- a/R-cdstoolchain/StartCDSToolChain.R
+++ b/R-cdstoolchain/StartCDSToolChain.R
@@ -259,10 +259,7 @@ tryCatch(
     if (any(grepl(allowed_pattern, error_lines))) {
       message("Ignoring expected error: ", e$message)
 
-      # Execute `next` only if not in the last iteration of the loop
-      if (i < length(DEBUG_DATES)) {
-        next
-      }
+      # Return to the caller; the debug runner controls its own day loop.
     } else {
       # the submodules log their errors itself -> we must check
       # if etlutils::isErrorOccured() and if TRUE then do nothing

--- a/R-cdstoolchain/cdstoolchain/tests/testthat/test-toolchain-error-handler.R
+++ b/R-cdstoolchain/cdstoolchain/tests/testthat/test-toolchain-error-handler.R
@@ -1,0 +1,53 @@
+# Load only the actual error handler, without starting the toolchain or connecting to services.
+loadToolchainErrorHandler <- function(env) {
+  expressions <- parse(testthat::test_path("..", "..", "..", "StartCDSToolChain.R"))
+  handlers <- Filter(function(expr) {
+    is.call(expr) && identical(expr[[1]], as.name("tryCatch")) && "error" %in% names(expr)
+  }, as.list(expressions))
+  stopifnot(length(handlers) == 1L)
+  eval(handlers[[1]][["error"]], envir = env)
+}
+
+test_that("expected column errors return without requiring a debug loop", {
+  env <- new.env(parent = baseenv())
+  handler <- loadToolchainErrorHandler(env)
+  for (debug_index in list(NULL, 1L, 2L)) {
+    env$i <- debug_index
+    env$DEBUG_DATES <- c("day1", "day2")
+    expect_message(
+      expect_null(handler(simpleError("column foo of relation bar does not exist"))),
+      "Ignoring expected error: column foo of relation bar does not exist",
+      fixed = TRUE
+    )
+  }
+})
+
+test_that("unexpected toolchain errors retain their message and failure exit status", {
+  logged <- NULL
+  exit_status <- NULL
+  testthat::local_mocked_bindings(
+    isErrorOccured = function() FALSE,
+    catErrorMessage = function(msg) logged <<- msg,
+    .package = "etlutils"
+  )
+  env <- new.env(parent = baseenv())
+  env$quit <- function(status, save) {
+    exit_status <<- status
+    expect_identical(save, "no")
+  }
+  handler <- loadToolchainErrorHandler(env)
+  handler(simpleError("original error"))
+  expect_identical(logged, "original error")
+  expect_identical(exit_status, 1)
+})
+
+test_that("already logged module errors return to the existing final status handling", {
+  testthat::local_mocked_bindings(
+    isErrorOccured = function() TRUE,
+    catErrorMessage = function(...) stop("must not log twice"),
+    .package = "etlutils"
+  )
+  env <- new.env(parent = baseenv())
+  env$quit <- function(...) stop("must not quit inside the handler")
+  expect_null(loadToolchainErrorHandler(env)(simpleError("module error")))
+})

--- a/R-db2frontend/db2frontend/DESCRIPTION
+++ b/R-db2frontend/db2frontend/DESCRIPTION
@@ -20,4 +20,6 @@ Imports:
     data.table,
     etlutils,
     redcapAPI
+Suggests:
+    testthat (>= 3.2.0)
 Config/roxygen2/version: 8.0.0

--- a/R-db2frontend/db2frontend/R/02_Frontend_To_DB.R
+++ b/R-db2frontend/db2frontend/R/02_Frontend_To_DB.R
@@ -38,7 +38,9 @@ importRedcap2DB <- function() {
           # fallback: In case of problems with the delimiters in REDCap, extend form names to "name,Name" and try again
           # extract allowed values from error message
           msg <- conditionMessage(e)
-          allowed_strings <- regmatches(msg, gregexpr("\\{([^}]*)\\}", msg))[[1]][[1]]
+          allowed_strings <- regmatches(msg, gregexpr("\\{([^}]*)\\}", msg))[[1]]
+          # Other export errors may not contain a list of allowed form names.
+          if (length(allowed_strings)) allowed_strings <- allowed_strings[[1]]
           allowed_strings <- gsub("^\\{|\\}$", "", allowed_strings)
           allowed_strings <- unlist(strsplit(allowed_strings, "','", fixed = TRUE))
           allowed_strings <- gsub("^'|'$", "", allowed_strings)
@@ -47,7 +49,7 @@ importRedcap2DB <- function() {
           if (length(match_val)) {
             return(data.table::setDT(suppressWarnings(redcapAPI::exportRecordsTyped(rcon = frontend_connection, forms = match_val))))
           }
-          stop("Error exporting records for REDCap form name '", form_name, "': ", e$message)
+          stop("Error exporting records for REDCap form name '", form_name, "': ", msg)
         }
       )
 

--- a/R-db2frontend/db2frontend/tests/testthat.R
+++ b/R-db2frontend/db2frontend/tests/testthat.R
@@ -1,0 +1,4 @@
+library(testthat)
+library(db2frontend)
+
+test_check("db2frontend")

--- a/R-db2frontend/db2frontend/tests/testthat/test-frontend-to-db.R
+++ b/R-db2frontend/db2frontend/tests/testthat/test-frontend-to-db.R
@@ -1,0 +1,41 @@
+test_that("importRedcap2DB preserves export errors without a matching form list", {
+  testthat::local_mocked_bindings(
+    getRedcapConnection = function() NULL,
+    getFrontendTableDescription = function() list(medikationsanalyse = NULL)
+  )
+
+  for (original_message in c("API request failed", "Invalid forms: {'patient','fall'}")) {
+    testthat::local_mocked_bindings(
+      exportRecordsTyped = function(...) stop(original_message),
+      .package = "redcapAPI"
+    )
+
+    expect_error(
+      importRedcap2DB(),
+      paste0("Error exporting records for REDCap form name 'medikationsanalyse': ", original_message),
+      fixed = TRUE
+    )
+  }
+})
+
+test_that("importRedcap2DB retains the form name fallback", {
+  testthat::local_mocked_bindings(
+    getRedcapConnection = function() NULL,
+    getFrontendTableDescription = function() list(medikationsanalyse = NULL)
+  )
+  requested_forms <- character()
+  testthat::local_mocked_bindings(
+    exportRecordsTyped = function(rcon, forms) {
+      requested_forms <<- c(requested_forms, forms)
+      if (length(requested_forms) == 1L) {
+        stop("Invalid forms: {'patient','medikationsanalyse,Medikationsanalyse'}")
+      }
+      # Stop before downstream processing to test the export retry in isolation.
+      stop("Retry reached")
+    },
+    .package = "redcapAPI"
+  )
+
+  expect_error(importRedcap2DB(), "Retry reached", fixed = TRUE)
+  expect_identical(requested_forms, c("medikationsanalyse", "medikationsanalyse,Medikationsanalyse"))
+})

--- a/R-etlutils/etlutils/R/lib_db.R
+++ b/R-etlutils/etlutils/R/lib_db.R
@@ -711,6 +711,26 @@ dbUnlock <- function(lock_id, readonly = FALSE) {
 }
 
 
+# Run a locked operation while retaining its original error if cleanup also fails.
+# Unlock failures after successful operations must still propagate as errors.
+dbWithLock <- function(lock_id, readonly, process) {
+  dbLock(lock_id)
+  original_error <- NULL
+  on.exit(
+    {
+      tryCatch(
+        dbUnlock(lock_id, readonly),
+        error = function(error) {
+          if (is.null(original_error)) stop(error)
+          message("Additionally failed to unlock database: ", conditionMessage(error))
+        }
+      )
+    },
+    add = TRUE
+  )
+  withCallingHandlers(process, error = function(error) original_error <<- error)
+}
+
 #' Forcefully Reset a Database Lock for a Project
 #'
 #' This function forcibly resets the database lock for a specified project
@@ -950,21 +970,19 @@ dbAddContent <- function(table_name, table, lock_id = NULL) {
     }
 
     # Lock + connection with guaranteed cleanup
-    dbLock(lock_id)
-    on.exit(dbUnlock(lock_id), add = TRUE)
-
-    dbWithRetry(
-      db_call = function(db_connection) {
-        RPostgres::dbAppendTable(db_connection, table_name, table)
-      },
-      call_label = "RPostgres::dbAppendTable",
-      sql = paste0("APPEND TABLE ", table_name),
-      readonly = FALSE
-    )
+    dbWithLock(lock_id, readonly = FALSE, {
+      dbWithRetry(
+        db_call = function(db_connection) {
+          RPostgres::dbAppendTable(db_connection, table_name, table)
+        },
+        call_label = "RPostgres::dbAppendTable",
+        sql = paste0("APPEND TABLE ", table_name),
+        readonly = FALSE
+      )
+      duration <- difftime(Sys.time(), time0, units = "secs")
+      dbLog("Inserted in ", table_name, ", ", row_count, " rows (took ", duration, " seconds)")
+    })
   }
-
-  duration <- difftime(Sys.time(), time0, units = "secs")
-  dbLog("Inserted in ", table_name, ", ", row_count, " rows (took ", duration, " seconds)")
 }
 
 #' Delete All Rows from a PostgreSQL Table
@@ -1126,17 +1144,17 @@ dbWithRetry <- function(db_call,
 #' @seealso \code{\link[DBI]{dbExecute}} for executing SQL statements.
 #'
 dbExecute <- function(statement, lock_id = NULL, readonly = FALSE) {
-  dbLock(lock_id)
-  on.exit(dbUnlock(lock_id, readonly), add = TRUE)
-  dbLog("dbExecute:\n", statement, dont_repeat_key = "dbExecute()")
-  dbWithRetry(
-    db_call = function(db_connection) {
-      DBI::dbExecute(db_connection, statement)
-    },
-    call_label = "DBI::dbExecute",
-    sql = statement,
-    readonly = readonly
-  )
+  dbWithLock(lock_id, readonly = readonly, {
+    dbLog("dbExecute:\n", statement, dont_repeat_key = "dbExecute()")
+    dbWithRetry(
+      db_call = function(db_connection) {
+        DBI::dbExecute(db_connection, statement)
+      },
+      call_label = "DBI::dbExecute",
+      sql = statement,
+      readonly = readonly
+    )
+  })
 }
 
 #' Execute a SQL Query on a PostgreSQL Database
@@ -1164,24 +1182,24 @@ dbExecute <- function(statement, lock_id = NULL, readonly = FALSE) {
 #'
 #' @export
 dbGetQuery <- function(query, params = NULL, lock_id = NULL, readonly = FALSE) {
-  dbLock(lock_id)
-  on.exit(dbUnlock(lock_id, readonly), add = TRUE)
-  dbLog(
-    "dbGetQuery:\n", query,
-    if (!is.null(params)) paste0("\n with params: ", paste0(names(params), "=", unlist(params), collapse = ", ")),
-    dont_repeat_key = "dbGetQuery()"
-  )
-  table <- dbWithRetry(
-    db_call = function(db_connection) {
-      data.table::as.data.table(DBI::dbGetQuery(db_connection, query, params = params))
-    },
-    call_label = "DBI::dbGetQuery",
-    sql = query,
-    readonly = readonly,
-    params = params
-  )
+  dbWithLock(lock_id, readonly = readonly, {
+    dbLog(
+      "dbGetQuery:\n", query,
+      if (!is.null(params)) paste0("\n with params: ", paste0(names(params), "=", unlist(params), collapse = ", ")),
+      dont_repeat_key = "dbGetQuery()"
+    )
+    table <- dbWithRetry(
+      db_call = function(db_connection) {
+        data.table::as.data.table(DBI::dbGetQuery(db_connection, query, params = params))
+      },
+      call_label = "DBI::dbGetQuery",
+      sql = query,
+      readonly = readonly,
+      params = params
+    )
 
-  return(table)
+    return(table)
+  })
 }
 
 #' Execute a Read-Only SQL Query on a PostgreSQL Database
@@ -1228,18 +1246,18 @@ dbGetReadOnlyQuery <- function(query, params = NULL, lock_id = NULL) {
 dbReadTable <- function(table_name, lock_id = NULL) {
   # Postgres only accepts lower case names -> convert them hard here
   table_name <- tolower(table_name)
-  dbLock(lock_id)
-  on.exit(dbUnlock(lock_id, readonly = TRUE), add = TRUE)
-  dbLog("dbReadTable: ", table_name)
-  table <- dbWithRetry(
-    db_call = function(db_connection) {
-      data.table::as.data.table(DBI::dbReadTable(db_connection, table_name))
-    },
-    call_label = "DBI::dbReadTable",
-    sql = paste0("READ TABLE ", table_name),
-    readonly = TRUE
-  )
-  return(table)
+  dbWithLock(lock_id, readonly = TRUE, {
+    dbLog("dbReadTable: ", table_name)
+    table <- dbWithRetry(
+      db_call = function(db_connection) {
+        data.table::as.data.table(DBI::dbReadTable(db_connection, table_name))
+      },
+      call_label = "DBI::dbReadTable",
+      sql = paste0("READ TABLE ", table_name),
+      readonly = TRUE
+    )
+    return(table)
+  })
 }
 
 
@@ -1348,14 +1366,13 @@ dbWriteTables <- function(tables, lock_id = NULL, stop_if_table_not_empty = FALS
   }
 
   # Write tables (lock guaranteed to be released)
-  dbLock(lock_id)
-  on.exit(dbUnlock(lock_id), add = TRUE)
-
-  for (table_name in table_names) {
-    table <- tables[[table_name]]
-    dbCheckColumsWidthBeforeWrite(table_name, table)
-    dbAddContent(table_name, table)
-  }
+  dbWithLock(lock_id, readonly = FALSE, {
+    for (table_name in table_names) {
+      table <- tables[[table_name]]
+      dbCheckColumsWidthBeforeWrite(table_name, table)
+      dbAddContent(table_name, table)
+    }
+  })
 }
 
 #' Write a Single Table to a PostgreSQL Database
@@ -1433,26 +1450,25 @@ dbReadTables <- function(table_names = NA, lock_id = NULL) {
   tables <- list()
 
   # Lock the database before reading; guarantee unlock even on error
-  dbLock(lock_id)
-  on.exit(dbUnlock(lock_id, readonly = TRUE), add = TRUE)
-
-  # Loop through each requested table
-  for (table_name in table_names) {
-    # Handle views prefixed with "v_"
-    if (!table_name %in% db_table_names) {
-      table_name <- paste0("v_", table_name)
+  dbWithLock(lock_id, readonly = TRUE, {
+    # Loop through each requested table
+    for (table_name in table_names) {
+      # Handle views prefixed with "v_"
+      if (!table_name %in% db_table_names) {
+        table_name <- paste0("v_", table_name)
+      }
+      # Extract the corresponding resource table name
+      resource_table_name <- if (grepl("^v_", table_name)) {
+        sub("^v_", "", table_name)
+      } else {
+        table_name
+      }
+      # Read the table via wrapper (does its own logging etc.)
+      tables[[resource_table_name]] <- dbReadTable(table_name)
     }
-    # Extract the corresponding resource table name
-    resource_table_name <- if (grepl("^v_", table_name)) {
-      sub("^v_", "", table_name)
-    } else {
-      table_name
-    }
-    # Read the table via wrapper (does its own logging etc.)
-    tables[[resource_table_name]] <- dbReadTable(table_name)
-  }
 
-  return(tables)
+    return(tables)
+  })
 }
 
 #' Print Database Timezone and Current Time
@@ -1732,61 +1748,60 @@ dbReset <- function(tables_with_schema = NULL) {
   on.exit(invisible(try(suppressWarnings(DBI::dbDisconnect(con)), silent = TRUE)), add = TRUE)
 
   lock_id <- "Clear database"
-  dbLock(lock_id)
-  on.exit(dbUnlock(lock_id), add = TRUE)
+  dbWithLock(lock_id, readonly = FALSE, {
+    if (is.null(tables_with_schema)) {
+      # Convert schemas vector into SQL-friendly format
+      schema_list <- paste0("'", .lib_db_env[["DB_ADMIN_SCHEMAS"]], "'", collapse = ", ")
+      query <- paste0("SELECT schemaname, tablename FROM pg_tables WHERE schemaname IN (", schema_list, ");")
 
-  if (is.null(tables_with_schema)) {
-    # Convert schemas vector into SQL-friendly format
-    schema_list <- paste0("'", .lib_db_env[["DB_ADMIN_SCHEMAS"]], "'", collapse = ", ")
-    query <- paste0("SELECT schemaname, tablename FROM pg_tables WHERE schemaname IN (", schema_list, ");")
-
-    # Get all tables to clear
-    tables <- DBI::dbGetQuery(con, query)
-  } else {
-    tables <- data.table::data.table(full = tables_with_schema)[
-      , c("schemaname", "tablename") := data.table::tstrsplit(full, ".", fixed = TRUE)
-    ][, !"full"]
-  }
-
-  # Clear all tables in the provided schemas
-  for (i in seq_len(nrow(tables))) {
-    schema <- tables$schemaname[i]
-    table_name <- tables$tablename[i]
-
-    truncate_statement <- paste0("TRUNCATE TABLE ", schema, ".", table_name, " RESTART IDENTITY CASCADE;")
-
-    tryCatch(
-      {
-        DBI::dbExecute(con, truncate_statement)
-      },
-      error = function(e) {
-        message("Error truncating table: ", schema, ".", table_name)
-        message("Error message: ", e$message)
-      }
-    )
-  }
-
-  # Check if tables still contain data after truncation
-  remaining_data <- data.table()
-  for (i in seq_len(nrow(tables))) {
-    schema <- tables$schemaname[i]
-    table_name <- tables$tablename[i]
-
-    query <- paste0("SELECT COUNT(*) AS row_count FROM ", schema, ".", table_name, ";")
-    row_count <- DBI::dbGetQuery(con, query)$row_count
-
-    if (row_count > 0) {
-      remaining_data <- data.table::rbindlist(list(remaining_data, data.table(SCHEMA = schema, TABLE = table_name, ROWS = row_count)))
+      # Get all tables to clear
+      tables <- DBI::dbGetQuery(con, query)
+    } else {
+      tables <- data.table::data.table(full = tables_with_schema)[
+        , c("schemaname", "tablename") := data.table::tstrsplit(full, ".", fixed = TRUE)
+      ][, !"full"]
     }
-  }
 
-  # Print results
-  if (nrow(remaining_data) > 0) {
-    print("The following tables still contain data after truncation:")
-    print(remaining_data)
-  } else {
-    print("All tables have been successfully truncated.")
-  }
+    # Clear all tables in the provided schemas
+    for (i in seq_len(nrow(tables))) {
+      schema <- tables$schemaname[i]
+      table_name <- tables$tablename[i]
+
+      truncate_statement <- paste0("TRUNCATE TABLE ", schema, ".", table_name, " RESTART IDENTITY CASCADE;")
+
+      tryCatch(
+        {
+          DBI::dbExecute(con, truncate_statement)
+        },
+        error = function(e) {
+          message("Error truncating table: ", schema, ".", table_name)
+          message("Error message: ", e$message)
+        }
+      )
+    }
+
+    # Check if tables still contain data after truncation
+    remaining_data <- data.table()
+    for (i in seq_len(nrow(tables))) {
+      schema <- tables$schemaname[i]
+      table_name <- tables$tablename[i]
+
+      query <- paste0("SELECT COUNT(*) AS row_count FROM ", schema, ".", table_name, ";")
+      row_count <- DBI::dbGetQuery(con, query)$row_count
+
+      if (row_count > 0) {
+        remaining_data <- data.table::rbindlist(list(remaining_data, data.table(SCHEMA = schema, TABLE = table_name, ROWS = row_count)))
+      }
+    }
+
+    # Print results
+    if (nrow(remaining_data) > 0) {
+      print("The following tables still contain data after truncation:")
+      print(remaining_data)
+    } else {
+      print("All tables have been successfully truncated.")
+    }
+  })
 }
 
 #' Remove Special Characters from a SQL comment.

--- a/R-etlutils/etlutils/R/lib_table.R
+++ b/R-etlutils/etlutils/R/lib_table.R
@@ -223,17 +223,30 @@ getTableFromList <- function(list, colNames) {
 #'
 #' @return A list of imported sheets as data.tables.
 #'
+#' @details Errors reading the workbook or a sheet stop the import and include the file path,
+#' sheet name where available, and the original error message. No partial result is returned.
+#'
 #' @export
 readExcelFileAsTableList <- function(excelFile, maxSheetIndex = 1000) {
+  sheet_names <- tryCatch(
+    openxlsx::getSheetNames(excelFile),
+    error = function(error) {
+      stop("Could not read Excel workbook '", excelFile, "': ", conditionMessage(error), call. = FALSE)
+    }
+  )
+  sheet_names <- sheet_names[seq_len(min(length(sheet_names), maxSheetIndex))]
   tables <- list()
-  for (excelSheetIndex in 1:maxSheetIndex) {
-    excelSheet <- try(setDT(openxlsx::read.xlsx(excelFile, excelSheetIndex, skipEmptyRows = FALSE, colNames = TRUE)), silent = TRUE)
-    if (isError(excelSheet)) break
-    tables <- append(tables, list(excelSheet))
-  }
-  sheetNames <- try(openxlsx::getSheetNames(excelFile), silent = TRUE)
-  if (!isError(sheetNames)) {
-    names(tables) <- sheetNames
+  for (sheet_name in sheet_names) {
+    tables[[sheet_name]] <- tryCatch(
+      data.table::as.data.table(openxlsx::read.xlsx(excelFile, sheet_name, skipEmptyRows = FALSE, colNames = TRUE)),
+      error = function(error) {
+        stop(
+          "Could not read Excel workbook '", excelFile, "', sheet '", sheet_name, "': ",
+          conditionMessage(error),
+          call. = FALSE
+        )
+      }
+    )
   }
   tables
 }

--- a/R-etlutils/etlutils/tests/testthat/test-db-lock-cleanup.R
+++ b/R-etlutils/etlutils/tests/testthat/test-db-lock-cleanup.R
@@ -1,0 +1,116 @@
+test_that("dbWithLock preserves results, visibility and lock arguments", {
+  events <- list()
+  testthat::local_mocked_bindings(
+    dbLock = function(lock_id) events[[length(events) + 1L]] <<- list("lock", lock_id),
+    dbUnlock = function(lock_id, readonly) events[[length(events) + 1L]] <<- list("unlock", lock_id, readonly)
+  )
+  result <- withVisible(dbWithLock("test", TRUE, invisible(42L)))
+  expect_identical(result, list(value = 42L, visible = FALSE))
+  expect_identical(events, list(list("lock", "test"), list("unlock", "test", TRUE)))
+})
+
+test_that("dbWithLock preserves the original condition when unlocking fails", {
+  original_error <- structure(list(message = "SQL failed", call = NULL), class = c("sql_error", "error", "condition"))
+  testthat::local_mocked_bindings(
+    dbLock = function(...) NULL,
+    dbUnlock = function(...) stop("unlock failed")
+  )
+  expect_message(
+    result <- tryCatch(dbWithLock("test", FALSE, stop(original_error)), error = identity),
+    "Additionally failed to unlock database: unlock failed",
+    fixed = TRUE
+  )
+  expect_identical(result, original_error)
+  expect_error(dbWithLock("test", FALSE, 42L), "unlock failed", fixed = TRUE)
+})
+
+test_that("dbWithLock does not unlock after a failed lock or suppress operation errors", {
+  unlocked <- FALSE
+  testthat::local_mocked_bindings(
+    dbLock = function(...) stop("lock failed"),
+    dbUnlock = function(...) unlocked <<- TRUE
+  )
+  expect_error(dbWithLock("test", FALSE, stop("must not run")), "lock failed", fixed = TRUE)
+  expect_false(unlocked)
+  testthat::local_mocked_bindings(dbLock = function(...) NULL)
+  expect_error(dbWithLock(NULL, FALSE, stop("SQL failed")), "SQL failed", fixed = TRUE)
+  expect_true(unlocked)
+})
+
+test_that("database entry points retain SQL failures through nested cleanup", {
+  testthat::local_mocked_bindings(
+    dbLock = function(...) NULL,
+    dbUnlock = function(lock_id, ...) {
+      if (!is.null(lock_id)) stop("unlock failed")
+    },
+    dbLog = function(...) NULL,
+    dbWithRetry = function(...) stop("SQL failed"),
+    dbListTableNames = function(...) "test",
+    dbGetReadOnlyColumns = function(...) character(),
+    dbCheckColumsWidthBeforeWrite = function(...) NULL
+  )
+  operations <- list(
+    function() dbExecute("SELECT broken", "test"),
+    function() dbGetQuery("SELECT broken", lock_id = "test"),
+    function() dbReadTable("test", "test"),
+    function() dbReadTables("test", "test"),
+    function() dbAddContent("test", data.table::data.table(id = 1L), "test"),
+    function() dbWriteTables(list(test = data.table::data.table(id = 1L)), "test")
+  )
+  for (operation in operations) {
+    expect_message(
+      expect_error(operation(), "SQL failed", fixed = TRUE),
+      "Additionally failed to unlock database: unlock failed",
+      fixed = TRUE
+    )
+  }
+})
+
+test_that("database reads and writes retain successful results and unlock once", {
+  unlocked <- list()
+  testthat::local_mocked_bindings(
+    dbLock = function(...) NULL,
+    dbUnlock = function(lock_id, readonly) unlocked[[length(unlocked) + 1L]] <<- list(lock_id, readonly),
+    dbLog = function(...) NULL,
+    dbWithRetry = function(...) 3L
+  )
+  expect_identical(dbExecute("UPDATE test", "write"), 3L)
+  expect_identical(dbGetQuery("SELECT test", lock_id = "read", readonly = TRUE), 3L)
+  expect_identical(dbReadTable("TEST", "table"), 3L)
+  expect_identical(unlocked, list(list("write", FALSE), list("read", TRUE), list("table", TRUE)))
+})
+
+test_that("dbReset retains a query error and closes its connection", {
+  disconnected <- FALSE
+  testthat::local_mocked_bindings(
+    dbGetAdminConnection = function() "test connection",
+    dbLock = function(...) NULL,
+    dbUnlock = function(...) stop("unlock failed")
+  )
+  testthat::local_mocked_bindings(
+    dbGetQuery = function(...) stop("SQL failed"),
+    dbDisconnect = function(...) disconnected <<- TRUE,
+    .package = "DBI"
+  )
+  expect_message(expect_error(dbReset(), "SQL failed", fixed = TRUE), "unlock failed", fixed = TRUE)
+  expect_true(disconnected)
+})
+
+test_that("dbAddContent preserves normalization and logs before unlocking", {
+  events <- character()
+  testthat::local_mocked_bindings(
+    dbGetReadOnlyColumns = function(...) "generated",
+    dbLock = function(...) events <<- c(events, "lock"),
+    dbUnlock = function(...) events <<- c(events, "unlock"),
+    dbWithRetry = function(...) events <<- c(events, "append"),
+    dbLog = function(...) events <<- c(events, "log")
+  )
+  table <- data.table::data.table(id = 1L, text = "", generated = 2L)
+  dbAddContent("TEST", table, "test")
+  expect_identical(names(table), c("id", "text"))
+  expect_true(is.na(table$text))
+  expect_identical(events, c("lock", "append", "log", "unlock"))
+  events <- character()
+  dbAddContent("TEST", table[0], "test")
+  expect_identical(events, character())
+})

--- a/R-etlutils/etlutils/tests/testthat/test-excel-read-errors.R
+++ b/R-etlutils/etlutils/tests/testthat/test-excel-read-errors.R
@@ -1,0 +1,46 @@
+test_that("readExcelFileAsTableList retains sheet names, values and read limits", {
+  path <- tempfile(fileext = ".xlsx")
+  on.exit(unlink(path), add = TRUE)
+  sheets <- list(first = data.frame(id = 1:2, text = c("a", "b")), second = data.frame(value = 3L))
+  openxlsx::write.xlsx(sheets, path)
+  result <- readExcelFileAsTableList(path)
+  expect_identical(names(result), names(sheets))
+  expect_true(all(vapply(result, data.table::is.data.table, logical(1))))
+  expect_equal(lapply(result, as.data.frame), sheets)
+  expect_equal(readExcelFileAsTableList(path, 1), result[1])
+  expect_identical(readExcelFileAsTableList(path, 0), list())
+  expect_equal(readExcelFileAsTableList(path, 10), result)
+})
+
+test_that("readExcelFileAsTableList preserves the workbook error", {
+  testthat::local_mocked_bindings(
+    getSheetNames = function(...) stop("original workbook failure"),
+    .package = "openxlsx"
+  )
+  expect_error(
+    readExcelFileAsTableList("test.xlsx"),
+    "Could not read Excel workbook 'test.xlsx': original workbook failure",
+    fixed = TRUE
+  )
+})
+
+test_that("readExcelFileAsTableList fails with sheet context instead of returning partial data", {
+  requested_sheets <- character()
+  testthat::local_mocked_bindings(
+    getSheetNames = function(...) c("first", "broken", "last"),
+    read.xlsx = function(xlsxFile, sheet, skipEmptyRows, colNames) {
+      requested_sheets <<- c(requested_sheets, sheet)
+      expect_false(skipEmptyRows)
+      expect_true(colNames)
+      if (sheet == "broken") stop("original sheet failure")
+      data.frame(id = 1L)
+    },
+    .package = "openxlsx"
+  )
+  expect_error(
+    readExcelFileAsTableList("test.xlsx"),
+    "Could not read Excel workbook 'test.xlsx', sheet 'broken': original sheet failure",
+    fixed = TRUE
+  )
+  expect_identical(requested_sheets, c("first", "broken"))
+})

--- a/R-etlutils/etlutils/tests/testthat/test-lib_table.R
+++ b/R-etlutils/etlutils/tests/testthat/test-lib_table.R
@@ -215,9 +215,11 @@ test_that("readExcelFileAsTableList imports Excel sheets correctly", {
   expect_equal(length(result), 2, info = "The result list should contain two data.tables for the two sheets.")
   expect_equal(names(result), c("mtcars_with_description_lines", "mtcars_without_description_line"))
 
-  # reading non existing files returns an empty list
-  result <- readExcelFileAsTableList("not_existing_file_path")
-  expect_true(length(result) == 0 && is.list(result))
+  expect_error(
+    readExcelFileAsTableList("not_existing_file_path"),
+    "Could not read Excel workbook 'not_existing_file_path':",
+    fixed = TRUE
+  )
 })
 
 ##################


### PR DESCRIPTION
## Problem und Änderung

Beim Export eines REDCap-Formulars kann der Fehlerhandler die eigentliche Ursache durch `subscript out of bounds` verdecken, wenn die Fehlermeldung keine Liste zulässiger Formularnamen enthält. Der Handler prüft den Treffer vor dem Zugriff und meldet Formularname und ursprünglichen Fehler. Der bestehende Fallback für Formularnamen bleibt erhalten.

Der Branch behebt außerdem drei verwandte Fehlerbehandlungen:
- Ein gemeinsamer `dbWithLock()`-Helfer erhält den ursprünglichen Datenbankfehler, wenn zusätzlich die Sperrenfreigabe scheitert. Nach erfolgreicher Operation wird ein Fehler der Sperrenfreigabe weiterhin weitergegeben.
- Der Toolchain-Fehlerhandler überlässt die Tagesiteration dem Debug-Runner und verwendet kein dort unzulässiges `next` mehr.
- Excel-Lesefehler brechen mit Dateipfad, gegebenenfalls Blattname und ursprünglicher Ursache ab, statt einen unvollständigen Import zurückzugeben.

## Validierung

276 erfolgreiche Testprüfungen am 18.09.2026 nach Zusammenführung mit `develop`: 243 in etlutils, 23 für REDCap-Import und frontend2db sowie 10 für den Toolchain-Fehlerhandler; keine Fehler, Warnungen oder übersprungenen Prüfungen. Die Tests decken insbesondere ursprüngliche und zusätzliche Fehler, erfolgreiche Rückgaben sowie die Sperrenfreigabe ab. `git diff --check` ist sauber.

Die Datenbank-Fehlerfälle wurden mit Mocks geprüft. Ein Integrationstest der geänderten Sperrenbehandlung mit echtem PostgreSQL steht noch aus. Der separate Toolchain-/REDCap-Integrationslauf für #1439 enthielt diese Änderungen nicht.

Closes #1433
